### PR TITLE
Use unzip on mac to extract vs code

### DIFF
--- a/WPILibInstaller-Avalonia/Models/VSCodeModel.cs
+++ b/WPILibInstaller-Avalonia/Models/VSCodeModel.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using WPILibInstaller_Avalonia.Utils;
 
 namespace WPILibInstaller_Avalonia.Models
@@ -23,6 +24,8 @@ namespace WPILibInstaller_Avalonia.Models
 
         public IArchiveExtractor? ToExtractArchive { get; set; }
 
+        public Stream? ToExtractArchiveMacOs { get; set; }
+
         public bool AlreadyInstalled { get; set; }
 
         public VsCodeModel(string vscodeVersion)
@@ -33,6 +36,7 @@ namespace WPILibInstaller_Avalonia.Models
         public void Dispose()
         {
             ToExtractArchive?.Dispose();
+            ToExtractArchiveMacOs?.Dispose();
         }
     }
 }

--- a/WPILibInstaller-Avalonia/ViewModels/ConfigurationPageViewModel.cs
+++ b/WPILibInstaller-Avalonia/ViewModels/ConfigurationPageViewModel.cs
@@ -30,7 +30,7 @@ namespace WPILibInstaller_Avalonia.ViewModels
 
         public bool CanInstallExtensions => vsProvider.Model.AlreadyInstalled || Model.InstallVsCode;
 
-        public bool CanInstallVsCode => vsProvider.Model.ToExtractArchive != null;
+        public bool CanInstallVsCode => vsProvider.Model.ToExtractArchive != null || vsProvider.Model.ToExtractArchiveMacOs != null;
 
         private readonly IVsCodeInstallLocationProvider vsProvider;
 

--- a/WPILibInstaller-Avalonia/ViewModels/InstallPageViewModel.cs
+++ b/WPILibInstaller-Avalonia/ViewModels/InstallPageViewModel.cs
@@ -275,17 +275,14 @@ namespace WPILibInstaller_Avalonia.ViewModels
 
             string intoPath = Path.Join(configurationProvider.InstallDirectory, "vscode");
 
-
             if (vsInstallProvider.Model.ToExtractArchiveMacOs != null)
             {
-                var zipPath = Path.Join(configurationProvider.InstallDirectory, "vscodezip", "MacVsCode.zip");
+                vsInstallProvider.Model.ToExtractArchiveMacOs.Seek(0, SeekOrigin.Begin);
+                var zipPath = Path.Join(intoPath, "MacVsCode.zip");
                 Directory.CreateDirectory(intoPath);
-                Directory.CreateDirectory(Path.Join(configurationProvider.InstallDirectory, "vscodezip"));
                 {
                     using var fileToWrite = new FileStream(zipPath, FileMode.Create, FileAccess.Write, FileShare.None);
                     await vsInstallProvider.Model.ToExtractArchiveMacOs.CopyToAsync(fileToWrite);
-                    await fileToWrite.FlushAsync();
-
                 }
                 await RunScriptExecutable("unzip", Timeout.Infinite, zipPath ,"-d", intoPath);
                 return;

--- a/WPILibInstaller-Avalonia/ViewModels/InstallPageViewModel.cs
+++ b/WPILibInstaller-Avalonia/ViewModels/InstallPageViewModel.cs
@@ -278,11 +278,13 @@ namespace WPILibInstaller_Avalonia.ViewModels
 
             if (vsInstallProvider.Model.ToExtractArchiveMacOs != null)
             {
-                var zipPath = Path.Join(intoPath, "MacVsCode.zip");
+                var zipPath = Path.Join(configurationProvider.InstallDirectory, "vscodezip", "MacVsCode.zip");
                 Directory.CreateDirectory(intoPath);
+                Directory.CreateDirectory(Path.Join(configurationProvider.InstallDirectory, "vscodezip"));
                 {
-                    using var fileToWrite = new FileStream(Path.Join(intoPath, "MacVsCode.zip"), FileMode.Create, FileAccess.Write, FileShare.None);
+                    using var fileToWrite = new FileStream(zipPath, FileMode.Create, FileAccess.Write, FileShare.None);
                     await vsInstallProvider.Model.ToExtractArchiveMacOs.CopyToAsync(fileToWrite);
+                    await fileToWrite.FlushAsync();
 
                 }
                 await RunScriptExecutable("unzip", Timeout.Infinite, zipPath ,"-d", intoPath);

--- a/WPILibInstaller-Avalonia/ViewModels/VSCodePageViewModel.cs
+++ b/WPILibInstaller-Avalonia/ViewModels/VSCodePageViewModel.cs
@@ -167,7 +167,14 @@ namespace WPILibInstaller_Avalonia.ViewModels
                 MemoryStream ms = new MemoryStream(100000000);
                 await entry!.Open().CopyToAsync(ms);
 
-                Model.ToExtractArchive = OpenArchive(ms);
+                if (OperatingSystem.IsMacOS())
+                {
+                    Model.ToExtractArchiveMacOs = ms;
+                }
+                else
+                {
+                    Model.ToExtractArchive = OpenArchive(ms);
+                }
             }
             catch
             {
@@ -229,7 +236,16 @@ namespace WPILibInstaller_Avalonia.ViewModels
             if (ms != null)
             {
                 ms.Seek(0, SeekOrigin.Begin);
-                Model.ToExtractArchive = OpenArchive(ms);
+
+                if (OperatingSystem.IsMacOS())
+                {
+                    Model.ToExtractArchiveMacOs = ms;
+                }
+                else
+                {
+                    Model.ToExtractArchive = OpenArchive(ms);
+                }
+
                 DoneText = "Done Downloading. Press Next to continue";
                 EnableSelectionButtons = true;
                 SetLocalForwardVisible(true);
@@ -250,7 +266,16 @@ namespace WPILibInstaller_Avalonia.ViewModels
             if (stream != null)
             {
                 Console.WriteLine("Trying to open archive");
-                Model.ToExtractArchive = OpenArchive(stream);
+
+                if (OperatingSystem.IsMacOS())
+                {
+                    Model.ToExtractArchiveMacOs = stream;
+                }
+                else
+                {
+                    Model.ToExtractArchive = OpenArchive(stream);
+                }
+
                 DoneText = "Done Downloading. Press Next to continue";
                 EnableSelectionButtons = true;
                 SetLocalForwardVisible(true);


### PR DESCRIPTION
I have no way to get file permissions from a zip file, so instead I must write to disk, and then call unzip on the zip