### PR TITLE
Add shebangs to tools Python scripts

### DIFF
--- a/WPILibInstaller-Avalonia/ViewModels/InstallPageViewModel.cs
+++ b/WPILibInstaller-Avalonia/ViewModels/InstallPageViewModel.cs
@@ -297,7 +297,7 @@ namespace WPILibInstaller.ViewModels
                     using var fileToWrite = new FileStream(zipPath, FileMode.Create, FileAccess.Write, FileShare.None);
                     await vsInstallProvider.Model.ToExtractArchiveMacOs.CopyToAsync(fileToWrite, token);
                 }
-                await RunExecutable("unzip", Timeout.Infinite, zipPath, "-d", intoPath);
+                await RunScriptExecutable("unzip", Timeout.Infinite, zipPath, "-d", intoPath);
                 return;
             }
 
@@ -475,27 +475,9 @@ namespace WPILibInstaller.ViewModels
             await Task.Yield();
         }
 
-        private Task<bool> RunExecutable(string exe, int timeoutMs, params string[] args)
-        {
-            ProcessStartInfo pstart = new ProcessStartInfo(exe, string.Join(" ", args));
-            var p = Process.Start(pstart);
-            return Task.Run(() =>
-            {
-                return p!.WaitForExit(timeoutMs);
-            });
-        }
-
         private Task<bool> RunScriptExecutable(string script, int timeoutMs, params string[] args)
         {
-            ProcessStartInfo pstart;
-            if (OperatingSystem.IsWindows())
-            {
-                pstart = new ProcessStartInfo(script, string.Join(" ", args));
-            }
-            else
-            {
-                pstart = new ProcessStartInfo("python3", script + " " + string.Join(" ", args));
-            }
+            ProcessStartInfo pstart = new ProcessStartInfo(script, string.Join(" ", args));
             var p = Process.Start(pstart);
             return Task.Run(() =>
             {

--- a/files/MavenMetaDataFixer.py
+++ b/files/MavenMetaDataFixer.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 from __future__ import print_function
 import sys
 import os

--- a/files/ScriptBase.py
+++ b/files/ScriptBase.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 from __future__ import print_function
 import sys
 import os

--- a/files/ToolsUpdater.py
+++ b/files/ToolsUpdater.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 from __future__ import print_function
 import sys
 import os


### PR DESCRIPTION
This lets Linux users run the scripts as "./OutlineViewer.py" instead of
just "python ./OutlineViewer.py".