### PR TITLE
Only copy permissions for wpilibinstaller executable

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -274,7 +274,7 @@ def copyInstallerFiles = tasks.register('copyInstallerFiles', Copy) {
         fileMode 0644
     }
     from (installDirectory) {
-        include ('WPILibInstaller', 'WPILibInstaller.app')
+        include ('WPILibInstaller', 'WPILibInstaller.app/**')
     }
 
     into "$buildDir/outputs"

--- a/build.gradle
+++ b/build.gradle
@@ -262,12 +262,6 @@ def versionFileTask = tasks.register('writeVersionNumber', Task) {
 
 
 def copyInstallerFiles = tasks.register('copyInstallerFiles', Copy) {
-    doFirst {
-        exec {
-            workingDir installDirectory
-            commandLine 'ls', '-alR'
-        }
-    }
 
     from (installDirectory) {
         exclude ('WPILibInstaller', 'WPILibInstaller.app')
@@ -283,12 +277,6 @@ def copyInstallerFiles = tasks.register('copyInstallerFiles', Copy) {
 
     from versionFile
 
-    doLast {
-        exec {
-            workingDir "$buildDir/outputs"
-            commandLine 'ls', '-alR'
-        }
-    }
 }
 
 def dotnetCreateImageTask = tasks.register('createDiskImage', Exec) {

--- a/build.gradle
+++ b/build.gradle
@@ -262,7 +262,15 @@ def versionFileTask = tasks.register('writeVersionNumber', Task) {
 
 
 def copyInstallerFiles = tasks.register('copyInstallerFiles', Copy) {
-    from installDirectory
+
+    from (installDirectory) {
+        exclude ('WPILibInstaller')
+        fileMode 0644
+    }
+    from (installDirectory) {
+        include ('WPILibInstaller')
+    }
+
     into "$buildDir/outputs"
     dependsOn dotnetInstallerTask
     dependsOn versionFileTask

--- a/build.gradle
+++ b/build.gradle
@@ -262,13 +262,19 @@ def versionFileTask = tasks.register('writeVersionNumber', Task) {
 
 
 def copyInstallerFiles = tasks.register('copyInstallerFiles', Copy) {
+    doFirst {
+        exec {
+            workingDir installDirectory
+            commandLine 'ls', '-al'
+        }
+    }
 
     from (installDirectory) {
-        exclude ('WPILibInstaller')
+        exclude ('WPILibInstaller', 'WPILibInstaller.app')
         fileMode 0644
     }
     from (installDirectory) {
-        include ('WPILibInstaller')
+        include ('WPILibInstaller', 'WPILibInstaller.app')
     }
 
     into "$buildDir/outputs"
@@ -276,6 +282,13 @@ def copyInstallerFiles = tasks.register('copyInstallerFiles', Copy) {
     dependsOn versionFileTask
 
     from versionFile
+
+    doLast {
+        exec {
+            workingDir "$buildDir/outputs"
+            commandLine 'ls', '-al'
+        }
+    }
 }
 
 def dotnetCreateImageTask = tasks.register('createDiskImage', Exec) {

--- a/build.gradle
+++ b/build.gradle
@@ -265,7 +265,7 @@ def copyInstallerFiles = tasks.register('copyInstallerFiles', Copy) {
     doFirst {
         exec {
             workingDir installDirectory
-            commandLine 'ls', '-al'
+            commandLine 'ls', '-alR'
         }
     }
 
@@ -286,7 +286,7 @@ def copyInstallerFiles = tasks.register('copyInstallerFiles', Copy) {
     doLast {
         exec {
             workingDir "$buildDir/outputs"
-            commandLine 'ls', '-al'
+            commandLine 'ls', '-alR'
         }
     }
 }


### PR DESCRIPTION
Fixes #94 by not copying permissions for the libraries.