### PR TITLE
Add error popup when shortcut creation fails

### DIFF
--- a/WPILibInstaller-Avalonia/ViewModels/InstallPageViewModel.cs
+++ b/WPILibInstaller-Avalonia/ViewModels/InstallPageViewModel.cs
@@ -642,7 +642,7 @@ namespace WPILibInstaller.ViewModels
                startInfo.WorkingDirectory = Environment.CurrentDirectory;
                if (shortcutData.IsAdmin)
                {
-                   startInfo.Verb = "runsas";
+                   startInfo.Verb = "runas";
                }
                var exitCode = await Task.Run(() =>
                {
@@ -653,8 +653,10 @@ namespace WPILibInstaller.ViewModels
 
                if (exitCode != 0)
                {
-                   // Print a message saying not all shortcuts were successful
-               }
+                    var result = await MessageBox.Avalonia.MessageBoxManager.GetMessageBoxStandardWindow("Warning",
+                   "Shortcut creation failed. Error Code: " + exitCode,
+                   icon: MessageBox.Avalonia.Enums.Icon.Warning, @enum: MessageBox.Avalonia.Enums.ButtonEnum.Ok).ShowDialog(programWindow.Window);
+                }
            }
            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
            {


### PR DESCRIPTION
Depends on #108 so that message is shown instead of exception
Fixes #84 
![image](https://user-images.githubusercontent.com/4885091/100003080-62190900-2d7a-11eb-83b4-37d4d2512762.png)
