### PR TITLE
Hide VS Code download progress bars that aren't used

### DIFF
--- a/WPILibInstaller-Avalonia/ViewModels/VSCodePageViewModel.cs
+++ b/WPILibInstaller-Avalonia/ViewModels/VSCodePageViewModel.cs
@@ -61,6 +61,14 @@ namespace WPILibInstaller.ViewModels
 
         private double progressBar1 = 0;
 
+        public Boolean ProgressBar1Visible
+        {
+            get => progressBar1Visible;
+            set => this.RaiseAndSetIfChanged(ref progressBar1Visible, value);
+        }
+
+        private Boolean progressBar1Visible = false;
+
         public double ProgressBar2
         {
             get => progressBar2;
@@ -68,6 +76,14 @@ namespace WPILibInstaller.ViewModels
         }
 
         private double progressBar2 = 0;
+
+        public Boolean ProgressBarAllVisible
+        {
+            get => progressBarAllVisible;
+            set => this.RaiseAndSetIfChanged(ref progressBarAllVisible, value);
+        }
+
+        private Boolean progressBarAllVisible = false;
 
         public double ProgressBar3
         {
@@ -190,6 +206,8 @@ namespace WPILibInstaller.ViewModels
         private async Task DownloadVsCodeFunc()
         {
             var currentPlatform = PlatformUtils.CurrentPlatform;
+            ProgressBar1Visible = true;
+            ProgressBarAllVisible = true;
 
             var file = await programWindow.ShowFolderPicker("Select Directory For VS Code File", Environment.GetFolderPath(Environment.SpecialFolder.Personal));
 
@@ -270,6 +288,7 @@ namespace WPILibInstaller.ViewModels
 
             EnableSelectionButtons = false;
             SetLocalForwardVisible(false);
+            ProgressBar1Visible = true;
 
             var (stream, platform) = await DownloadToMemoryStream(currentPlatform, url, CancellationToken.None, (d) => ProgressBar1 = d);
             if (stream != null)

--- a/WPILibInstaller-Avalonia/ViewModels/VSCodePageViewModel.cs
+++ b/WPILibInstaller-Avalonia/ViewModels/VSCodePageViewModel.cs
@@ -61,13 +61,13 @@ namespace WPILibInstaller.ViewModels
 
         private double progressBar1 = 0;
 
-        public Boolean ProgressBar1Visible
+        public bool ProgressBar1Visible
         {
             get => progressBar1Visible;
             set => this.RaiseAndSetIfChanged(ref progressBar1Visible, value);
         }
 
-        private Boolean progressBar1Visible = false;
+        private bool progressBar1Visible = false;
 
         public double ProgressBar2
         {
@@ -77,13 +77,13 @@ namespace WPILibInstaller.ViewModels
 
         private double progressBar2 = 0;
 
-        public Boolean ProgressBarAllVisible
+        public bool ProgressBarAllVisible
         {
             get => progressBarAllVisible;
             set => this.RaiseAndSetIfChanged(ref progressBarAllVisible, value);
         }
 
-        private Boolean progressBarAllVisible = false;
+        private bool progressBarAllVisible = false;
 
         public double ProgressBar3
         {

--- a/WPILibInstaller-Avalonia/Views/VSCodePage.xaml
+++ b/WPILibInstaller-Avalonia/Views/VSCodePage.xaml
@@ -36,10 +36,10 @@
       <Button Grid.Column="0" Grid.Row="1" Margin="0,0,5,0" IsEnabled="{Binding EnableSelectionButtons}" Content="{Binding SelectText}" Command="{Binding SelectVsCode}"/>
       <Button Grid.Column="1" Grid.Row="1" Margin="5,0,0,0" IsEnabled="{Binding EnableSelectionButtons}" Content="{Binding DownloadText}" Command="{Binding DownloadVsCode}"/>
       <StackPanel Margin="5,0,0,0" Grid.Column="2" Grid.Row="0" Grid.RowSpan="2">
-        <ProgressBar Value="{Binding ProgressBar1}" Margin="0,2,0,0" MinWidth="20" />
-        <ProgressBar Value="{Binding ProgressBar2}" Margin="0,2,0,0" MinWidth="20" />
-        <ProgressBar Value="{Binding ProgressBar3}" Margin="0,2,0,0" MinWidth="20" />
-        <ProgressBar Value="{Binding ProgressBar4}" Margin="0,2,0,0" MinWidth="20" />
+        <ProgressBar Value="{Binding ProgressBar1}" IsVisible="{Binding ProgressBar1Visible}" Margin="0,2,0,0" MinWidth="20" />
+        <ProgressBar Value="{Binding ProgressBar2}" IsVisible="{Binding ProgressBarAllVisible}" Margin="0,2,0,0" MinWidth="20" />
+        <ProgressBar Value="{Binding ProgressBar3}" IsVisible="{Binding ProgressBarAllVisible}" Margin="0,2,0,0" MinWidth="20" />
+        <ProgressBar Value="{Binding ProgressBar4}" IsVisible="{Binding ProgressBarAllVisible}" Margin="0,2,0,0" MinWidth="20" />
       </StackPanel>
     </Grid>
   </Grid>


### PR DESCRIPTION
Based on feedback from beta forums post6711

Before clicking a button:
![image](https://user-images.githubusercontent.com/4885091/100015865-74e90900-2d8d-11eb-8c41-2225c2bc7457.png)

After clicking Install Single:
![image](https://user-images.githubusercontent.com/4885091/100015900-7fa39e00-2d8d-11eb-919d-1ec279f80d32.png)

After clicking Install Offline:
![image](https://user-images.githubusercontent.com/4885091/100015953-8fbb7d80-2d8d-11eb-93c7-17e8ca0d3c70.png)
