### PR TITLE
Update Offline and skip descriptions for clarity

### DIFF
--- a/WPILibInstaller-Avalonia/ViewModels/VSCodePageViewModel.cs
+++ b/WPILibInstaller-Avalonia/ViewModels/VSCodePageViewModel.cs
@@ -50,7 +50,7 @@ namespace WPILibInstaller.ViewModels
             set => this.RaiseAndSetIfChanged(ref downloadText, value);
         }
 
-        private string selectText = "Select Existing VS Code Installer";
+        private string selectText = "Use Downloaded Offline Installer";
         private string downloadText = "Download VS Code for Offline Install";
 
         public double ProgressBar1

--- a/WPILibInstaller-Avalonia/Views/CanceledPage.xaml
+++ b/WPILibInstaller-Avalonia/Views/CanceledPage.xaml
@@ -2,7 +2,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+             mc:Ignorable="d" d:DesignWidth="640" d:DesignHeight="400"
              x:Class="WPILibInstaller.Views.CanceledPage">
   <StackPanel VerticalAlignment="Center">
     <TextBlock FontSize="20" HorizontalAlignment="Center" VerticalAlignment="Center">

--- a/WPILibInstaller-Avalonia/Views/ConfigurationPage.xaml
+++ b/WPILibInstaller-Avalonia/Views/ConfigurationPage.xaml
@@ -2,7 +2,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+             mc:Ignorable="d" d:DesignWidth="640" d:DesignHeight="400"
              x:Class="WPILibInstaller.Views.ConfigurationPage">
   <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
     <TextBlock Margin="0,0,0,20" FontSize="20" FontWeight="Bold">Select the items you would like to install.</TextBlock>

--- a/WPILibInstaller-Avalonia/Views/FailedPage.xaml
+++ b/WPILibInstaller-Avalonia/Views/FailedPage.xaml
@@ -2,7 +2,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+             mc:Ignorable="d" d:DesignWidth="640" d:DesignHeight="400"
              x:Class="WPILibInstaller.Views.FailedPage">
   <Grid RowDefinitions="1*,9*">
     <TextBlock Grid.Row="0" FontSize="20" HorizontalAlignment="Center" VerticalAlignment="Center">

--- a/WPILibInstaller-Avalonia/Views/FinalPage.xaml
+++ b/WPILibInstaller-Avalonia/Views/FinalPage.xaml
@@ -2,7 +2,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+             mc:Ignorable="d" d:DesignWidth="640" d:DesignHeight="400"
              x:Class="WPILibInstaller.Views.FinalPage">
   <StackPanel VerticalAlignment="Center">
     <TextBlock FontSize="20" HorizontalAlignment="Center" VerticalAlignment="Center">

--- a/WPILibInstaller-Avalonia/Views/InstallPage.xaml
+++ b/WPILibInstaller-Avalonia/Views/InstallPage.xaml
@@ -2,7 +2,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             mc:Ignorable="d" d:DesignWidth="600" d:DesignHeight="400"
+             mc:Ignorable="d" d:DesignWidth="640" d:DesignHeight="400"
              x:Class="WPILibInstaller.Views.InstallPage">
   <DockPanel LastChildFill="True">
     <ProgressBar DockPanel.Dock="Top"  Margin="10,10,10,10" Height="30" Value="{Binding Progress}"/>

--- a/WPILibInstaller-Avalonia/Views/MainWindow.xaml
+++ b/WPILibInstaller-Avalonia/Views/MainWindow.xaml
@@ -6,10 +6,10 @@
         xmlns:vm="clr-namespace:WPILibInstaller.ViewModels;assembly=WPILibInstaller"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-        mc:Ignorable="d" d:DesignWidth="600" d:DesignHeight="400"
+        mc:Ignorable="d" d:DesignWidth="640" d:DesignHeight="400"
         x:Class="WPILibInstaller.Views.MainWindow"
         Icon="/Assets/wpilib-256.ico"
-        Title="WPILib Installer" Width="600" Height="400">
+        Title="WPILib Installer" Width="640" Height="400">
 
   <Grid>
     <Grid.RowDefinitions>

--- a/WPILibInstaller-Avalonia/Views/StartPage.xaml
+++ b/WPILibInstaller-Avalonia/Views/StartPage.xaml
@@ -2,7 +2,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+             mc:Ignorable="d" d:DesignWidth="640" d:DesignHeight="400"
              x:Class="WPILibInstaller.Views.StartPage">
   <StackPanel HorizontalAlignment="Center"
               VerticalAlignment="Center">

--- a/WPILibInstaller-Avalonia/Views/VSCodePage.xaml
+++ b/WPILibInstaller-Avalonia/Views/VSCodePage.xaml
@@ -2,11 +2,11 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             mc:Ignorable="d" d:DesignWidth="600" d:DesignHeight="400"
+             mc:Ignorable="d" d:DesignWidth="640" d:DesignHeight="400"
              x:Class="WPILibInstaller.Views.VSCodePage">
   <Grid Margin="10">
     <Grid.RowDefinitions>
-      <RowDefinition Height="7*"/>
+      <RowDefinition Height="9*"/>
       <RowDefinition Height="1*"/>
       <RowDefinition Height="3*"/>
     </Grid.RowDefinitions>
@@ -15,9 +15,9 @@
     For licensing reasons, VS Code cannot be included in the WPILib Installer. WPILib installs it's own copy of VS Code every year, not shared between years or a system install. If you have already installed VS Code for the current year, the Next button will be enabled and you can skip this step, otherwise choose from the following options. VS Code will be installed on this system using the installer selected here in later steps.
 
     1. Download VS Code for Single Install: Use this if you don't plan on sharing the VS Code installer between systems. This will be the fastest download.
-    2. Select Existing VS Code Download: Use this to select a pre-existing installer zip file.
-    3. Download VS Code for Offline Install: Use this to download VS Code installers for all platforms, which can be shared between systems for offline use.
-    4. Skip installing VS Code. This will prompt unless already installed.
+    2. Skip installing VS Code. This will display a warning if a compatibible VS Code installation isn't detected.
+    3. Use Downloaded Offline Installer: Use this to select a installer zip file previously downloaded from this tool.
+    4. Download VS Code for Offline Install: Use this to download VS Code installers for all platforms, which can be shared between systems for offline use.
     </TextBlock>
     </ScrollViewer>
     <TextBlock TextWrapping="Wrap" Grid.Row="1" Height="15" FontWeight="Bold" FontSize="12" HorizontalAlignment="Center" VerticalAlignment="Center" Text="{Binding DoneText}"></TextBlock>


### PR DESCRIPTION
Change select existing to use downloaded
Adjust window size so screen still fits
Reorder descriptions to match button order

![image](https://user-images.githubusercontent.com/4885091/100526598-4305e700-317f-11eb-8228-35baa5b6601d.png)
