### PR TITLE
Fix ScriptBaseCpp.py on Linux

### DIFF
--- a/files/ScriptBaseCpp.py
+++ b/files/ScriptBaseCpp.py
@@ -7,10 +7,14 @@ import subprocess
 import sys
 
 script_name = os.path.abspath(sys.argv[0])
-exe_name = os.path.splitext(script_name)[0].lower()
+exe_name = os.path.splitext(script_name)[0]
 
-if platform.system() == "Darwin":
+if platform.system() == "Linux":
+    cmd = [exe_name.lower()]
+elif platform.system() == "Darwin":
     cmd = ["open", exe_name + ".app"]
+elif platform.system() == "Windows":
+    cmd = [exe_name + ".exe"]
 else:
     cmd = [exe_name]
 

--- a/files/ScriptBaseCpp.py
+++ b/files/ScriptBaseCpp.py
@@ -1,37 +1,22 @@
 #!/usr/bin/env python
 
 from __future__ import print_function
-import sys
 import os
-import subprocess
-import time
 import platform
+import subprocess
+import sys
 
-fullScript = os.path.abspath(sys.argv[0])
+script_name = os.path.abspath(sys.argv[0])
+exe_name = os.path.splitext(script_name)[0]
 
-scriptName = os.path.basename(sys.argv[0])
-scriptName = os.path.splitext(scriptName)[0]
-
-exeName = scriptName
-
-
-toolsFolder = os.path.dirname(fullScript)
-
-fullExeName = os.path.join(toolsFolder, exeName)
-
-if platform.system() == 'Darwin':
-  fullExeName = fullExeName + '.app'
-  runCommand = 'open'
+if platform.system() == "Darwin":
+    cmd = ["open", exe_name + ".app"]
 else:
-  runCommand = 'exec'
+    cmd = [exe_name]
 
 try:
-  subProc = subprocess.Popen([runCommand, fullExeName], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-  # If here, start succeeded
+    subprocess.Popen(cmd)
 except Exception as e:
-  # error
-  print('Error Launching Tool: ')
-  print(e)
-  exit(1)
-
-exit(0)
+    print("Error launching tool:")
+    print(e)
+    exit(1)

--- a/files/ScriptBaseCpp.py
+++ b/files/ScriptBaseCpp.py
@@ -7,7 +7,7 @@ import subprocess
 import sys
 
 script_name = os.path.abspath(sys.argv[0])
-exe_name = os.path.splitext(script_name)[0]
+exe_name = os.path.splitext(script_name)[0].lower()
 
 if platform.system() == "Darwin":
     cmd = ["open", exe_name + ".app"]


### PR DESCRIPTION
"exec" is a shell built-in, which can't be used to run a command without
the shell. However, Popen() doesn't spawn processes in a shell by
default anyway, so we can just call that and let the script exit.

I also simplified the script.