### PR TITLE
Don't sign outer macOS disk image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,14 +104,6 @@ jobs:
         run: |
           hdiutil create -volname WPILibInstaller -srcfolder pubOutputs/ -format UDRO WPILib_macOS-`/usr/libexec/PlistBuddy -c "Print CFBundleVersion" pubOutputs/WPILibInstaller.app/Contents/Info.plist`.dmg
 
-      - name: Sign DMG with Developer ID
-        working-directory: build
-        run: |
-          codesign -s ${{ secrets.APPLE_DEVELOPER_ID }} `ls *.dmg | head -1`
-        if: |
-          github.repository_owner == 'wpilibsuite' &&
-          (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v'))
-
       - name: Upload Installer DMG
         uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
This works around a Gatekeeper bug in macOS Mojave (10.14) where it will
reject a signed-but-unnotarized disk image. All versions of macOS should
still be able to open an unsigned disk image.