### PR TITLE
Verify SHA256 of artifacts tgz on macOS

### DIFF
--- a/WPILibInstaller-Avalonia/Views/StartPage.xaml
+++ b/WPILibInstaller-Avalonia/Views/StartPage.xaml
@@ -19,6 +19,10 @@
                VerticalAlignment="Center" />
     <TextBlock Text="The artifacts and/or resource files were not found. Please click the buttons below to select them."
                IsVisible="{Binding MissingEitherFile}"/>
+    <TextBlock Text="Verifying Artifacts File..."
+               IsVisible="{Binding MissingHash}"
+               HorizontalAlignment="Center"
+               FontSize="20"/>
     <Button Margin="0, 10, 0, 0" Content="Select Artifacts File (-artifacts)"
             Height="45"
             Command="{Binding SelectSupportFiles}"

--- a/build.gradle
+++ b/build.gradle
@@ -319,6 +319,15 @@ def unixCreateImageTask = tasks.register('createTarImage', Tar) {
     from("$buildDir/outputs")
 }
 
+def signResourcesTask = tasks.register('signResources', Exec) {
+    dependsOn generateFullResourcesTask
+    dependsOn copyInstallerFiles
+    workingDir = "$buildDir/outputs"
+
+    def file = 'WPILib_' + buildClassifier + '-' + pubVersion + '-artifacts' + '.tar.gz'
+    commandLine 'sh', '-c', "shasum -a 256 $file | cut -d \" \" -f 1 > WPILibInstaller.app/Contents/MacOS/checksum.txt"
+}
+
 tasks.register('generateInstallers', Task) {
     if (OperatingSystem.current().isWindows()) {
         dependsOn dotnetCreateImageTask
@@ -328,6 +337,7 @@ tasks.register('generateInstallers', Task) {
         dependsOn generateConfigFiles
         dependsOn generateFullResourcesTask
         dependsOn copyInstallerFiles
+        dependsOn signResourcesTask
     }
 }
 


### PR DESCRIPTION
This prevents a hypothetical re-packaging attack, where the notarized
installer application is packaged alongside a malicious sidecar payload
in a disk image. This also has the added benefit of preventing the user
from accidentally installing the wrong version if they have more than 1
WPILib disk image mounted.

Closes #58