### PR TITLE
Fix path to installer's java executable

### DIFF
--- a/files/MavenMetaDataFixer.py
+++ b/files/MavenMetaDataFixer.py
@@ -9,7 +9,7 @@ import time
 script_name = os.path.abspath(sys.argv[0])
 jar_name = os.path.splitext(script_name)[0] + ".jar"
 
-jdk_dir = os.path.join(os.path.dirname(jar_name), "jdk", "bin", "java")
+jdk_dir = os.path.join(os.path.dirname(jar_name), "..", "jdk", "bin", "java")
 
 try:
     p = subprocess.Popen(

--- a/files/ScriptBase.py
+++ b/files/ScriptBase.py
@@ -9,7 +9,7 @@ import time
 script_name = os.path.abspath(sys.argv[0])
 jar_name = os.path.splitext(script_name)[0] + ".jar"
 
-jdk_dir = os.path.join(os.path.dirname(jar_name), "jdk", "bin", "java")
+jdk_dir = os.path.join(os.path.dirname(jar_name), "..", "jdk", "bin", "java")
 
 try:
     p = subprocess.Popen(

--- a/files/ToolsUpdater.py
+++ b/files/ToolsUpdater.py
@@ -9,7 +9,7 @@ import time
 script_name = os.path.abspath(sys.argv[0])
 jar_name = os.path.splitext(script_name)[0] + ".jar"
 
-jdk_dir = os.path.join(os.path.dirname(jar_name), "jdk", "bin", "java")
+jdk_dir = os.path.join(os.path.dirname(jar_name), "..", "jdk", "bin", "java")
 
 try:
     p = subprocess.Popen(


### PR DESCRIPTION
Using dirname() twice is an option, but prepending ".." has a more
obvious intent.

Fixes #154.