### PR TITLE
Use GitHub releases for java debug+dependency vscode extensions

### DIFF
--- a/scripts/vscode.gradle
+++ b/scripts/vscode.gradle
@@ -37,13 +37,13 @@ def wpilibUtilLinuxZipName = 'utilitylinux.tar.gz'
 def wpilibUtilMacUrl = "https://github.com/wpilibsuite/vscode-wpilib/releases/download/v${wpilibVersion}/wpilibutility-mac.tar.gz"
 def wpilibUtilMacZipName = 'utilitymac.tar.gz'
 
-def javaDebugUrl = 'https://vscjava.gallery.vsassets.io/_apis/public/gallery/publisher/vscjava/extension/vscode-java-debug/0.30.0/assetbyname/Microsoft.VisualStudio.Services.VSIXPackage'
+def javaDebugUrl = 'https://github.com/microsoft/vscode-java-debug/releases/download/0.30.0/vscjava.vscode-java-debug-0.30.0.vsix'
 def javaDebugVsix = 'JavaDebug.vsix'
 
 def javaLangUrl = 'https://redhat.gallery.vsassets.io/_apis/public/gallery/publisher/redhat/extension/java/0.73.0/assetbyname/Microsoft.VisualStudio.Services.VSIXPackage'
 def javaLangVsix = "JavaLang.vsix"
 
-def javaDepUrl = 'https://vscjava.gallery.vsassets.io/_apis/public/gallery/publisher/vscjava/extension/vscode-java-dependency/0.16.0/assetbyname/Microsoft.VisualStudio.Services.VSIXPackage'
+def javaDepUrl = 'https://github.com/microsoft/vscode-java-dependency/releases/download/0.16.0/vscjava.vscode-java-dependency-0.16.0.vsix'
 def javaDepVsix = "JavaDeps.vsix"
 
 def javaLangFile = file("$buildDir/$javaLangVsix")


### PR DESCRIPTION
Closes #151.