### PR TITLE
Add advanced dev mode

### DIFF
--- a/WPILibInstaller-Avalonia/Interfaces/IDevModeChecker.cs
+++ b/WPILibInstaller-Avalonia/Interfaces/IDevModeChecker.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace WPILibInstaller.Interfaces
+{
+    public interface IDevModeChecker
+    {
+        bool DevMode { get; }
+    }
+}

--- a/WPILibInstaller-Avalonia/ViewModels/ConfigurationPageViewModel.cs
+++ b/WPILibInstaller-Avalonia/ViewModels/ConfigurationPageViewModel.cs
@@ -8,7 +8,7 @@ using WPILibInstaller.Models;
 
 namespace WPILibInstaller.ViewModels
 {
-    public class ConfigurationPageViewModel : PageViewModelBase, IToInstallProvider
+    public class ConfigurationPageViewModel : PageViewModelBase, IToInstallProvider, IDevModeChecker
     {
         private readonly IViewModelResolver viewModelResolver;
 
@@ -36,10 +36,13 @@ namespace WPILibInstaller.ViewModels
 
         public bool CanRunAsAdmin => RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
 
+        public bool DevMode { get; }
+
         public ConfigurationPageViewModel(IViewModelResolver viewModelResolver, IVsCodeInstallLocationProvider vsInstallProvider,
-            ICatchableButtonFactory buttonFactory)
+            ICatchableButtonFactory buttonFactory, IDevModeChecker devModeChecker)
             : base("Install", "Back")
         {
+            this.DevMode = devModeChecker.DevMode;
             this.viewModelResolver = viewModelResolver;
             this.vsProvider = vsInstallProvider;
             InstallLocalUser = buttonFactory.CreateCatchableButton(InstallLocalUserFunc);

--- a/WPILibInstaller-Avalonia/ViewModels/StartPageViewModel.cs
+++ b/WPILibInstaller-Avalonia/ViewModels/StartPageViewModel.cs
@@ -16,7 +16,7 @@ using System.Windows.Input;
 
 namespace WPILibInstaller.ViewModels
 {
-    public class StartPageViewModel : PageViewModelBase, IConfigurationProvider
+    public class StartPageViewModel : PageViewModelBase, IConfigurationProvider, IDevModeChecker
     {
 
         private readonly IProgramWindow programWindow;
@@ -334,8 +334,18 @@ namespace WPILibInstaller.ViewModels
             return true;
         }
 
+        private bool devMode = false;
+        public bool DevMode
+        {
+            get => devMode;
+            set => this.RaiseAndSetIfChanged(ref devMode, value);
+        }
+
         public void LogoClicked(object? o, RoutedEventArgs eventArgs) {
-            ClickCount++;
+            if (ClickCount++ > 9)
+            {
+                DevMode = true;
+            }
         }
 
         public async Task SelectSupportFilesFunc()

--- a/WPILibInstaller-Avalonia/ViewModels/StartPageViewModel.cs
+++ b/WPILibInstaller-Avalonia/ViewModels/StartPageViewModel.cs
@@ -2,7 +2,6 @@
 using ReactiveUI;
 using Avalonia.Interactivity;
 using System;
-using System.Diagnostics;
 using System.IO;
 using System.IO.Compression;
 using System.Reactive;
@@ -12,7 +11,6 @@ using System.Threading.Tasks;
 using WPILibInstaller.Interfaces;
 using WPILibInstaller.Models;
 using WPILibInstaller.Utils;
-using System.Windows.Input;
 
 namespace WPILibInstaller.ViewModels
 {
@@ -341,7 +339,8 @@ namespace WPILibInstaller.ViewModels
             set => this.RaiseAndSetIfChanged(ref devMode, value);
         }
 
-        public void LogoClicked(object? o, RoutedEventArgs eventArgs) {
+        public void LogoClicked(object? o, RoutedEventArgs eventArgs)
+        {
             if (ClickCount++ > 9)
             {
                 DevMode = true;

--- a/WPILibInstaller-Avalonia/ViewModels/StartPageViewModel.cs
+++ b/WPILibInstaller-Avalonia/ViewModels/StartPageViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using Newtonsoft.Json;
 using ReactiveUI;
+using Avalonia.Interactivity;
 using System;
 using System.Diagnostics;
 using System.IO;
@@ -11,6 +12,7 @@ using System.Threading.Tasks;
 using WPILibInstaller.Interfaces;
 using WPILibInstaller.Models;
 using WPILibInstaller.Utils;
+using System.Windows.Input;
 
 namespace WPILibInstaller.ViewModels
 {
@@ -130,6 +132,8 @@ namespace WPILibInstaller.ViewModels
             }
         }
 
+        private int ClickCount = 0;
+
         public bool MissingSupportFiles
         {
             get => missingSupportFiles;
@@ -164,7 +168,6 @@ namespace WPILibInstaller.ViewModels
         }
 
         private bool missingResourceFiles = true;
-
 
         public ReactiveCommand<Unit, Unit> SelectSupportFiles { get; }
         public ReactiveCommand<Unit, Unit> SelectResourceFiles { get; }
@@ -329,6 +332,10 @@ namespace WPILibInstaller.ViewModels
             ZipArchive = ArchiveUtils.OpenArchive(fileStream);
 
             return true;
+        }
+
+        public void LogoClicked(object? o, RoutedEventArgs eventArgs) {
+            ClickCount++;
         }
 
         public async Task SelectSupportFilesFunc()

--- a/WPILibInstaller-Avalonia/ViewModels/VSCodePageViewModel.cs
+++ b/WPILibInstaller-Avalonia/ViewModels/VSCodePageViewModel.cs
@@ -16,6 +16,16 @@ namespace WPILibInstaller.ViewModels
 {
     public class VSCodePageViewModel : PageViewModelBase, IVsCodeInstallLocationProvider
     {
+        private string baseInstallText = @"
+For licensing reasons, VS Code cannot be included in the WPILib Installer. WPILib installs it's own copy of VS Code every year, not shared between years or a system install. If you have already installed VS Code for the current year, the Next button will be enabled and you can skip this step, otherwise choose from the following options. VS Code will be installed on this system using the installer selected here in later steps.
+
+1. Download VS Code for Single Install: Use this if you don't plan on sharing the VS Code installer between systems. This will be the fastest download.
+2. Use Downloaded Offline Installer: Use this to select a installer zip file previously downloaded from this tool.
+3. Download VS Code for Offline Install: Use this to download VS Code installers for all platforms, which can be shared between systems for offline use.
+{0}";
+        private string vsCodeInstallText = "4. Skip installing VS Code. This will display a warning if a compatibible VS Code installation isn't detected.";
+        
+        public string InstallText { get; }
 
         public override bool ForwardVisible => forwardVisible;
 
@@ -114,9 +124,11 @@ namespace WPILibInstaller.ViewModels
         private readonly IProgramWindow programWindow;
         private readonly IMainWindowViewModel refresher;
         private readonly IViewModelResolver viewModelResolver;
+        
+        public bool DevMode { get; }
 
         public VSCodePageViewModel(IMainWindowViewModel mainRefresher, IProgramWindow programWindow, IConfigurationProvider modelProvider, IViewModelResolver viewModelResolver,
-            ICatchableButtonFactory buttonFactory)
+            ICatchableButtonFactory buttonFactory, IDevModeChecker devModeChecker)
             : base("Next", "Back")
         {
             SkipVsCode = buttonFactory.CreateCatchableButton(SkipVsCodeFunc);
@@ -124,11 +136,15 @@ namespace WPILibInstaller.ViewModels
             DownloadVsCode = buttonFactory.CreateCatchableButton(DownloadVsCodeFunc);
             SelectVsCode = buttonFactory.CreateCatchableButton(SelectVsCodeFunc);
 
+            
 
+            DevMode = devModeChecker.DevMode;
             this.refresher = mainRefresher;
             this.programWindow = programWindow;
             Model = modelProvider.VsCodeModel;
             this.viewModelResolver = viewModelResolver;
+
+            InstallText = string.Format(baseInstallText, DevMode ? vsCodeInstallText : "");
 
             refresher.RefreshForwardBackProperties();
 

--- a/WPILibInstaller-Avalonia/ViewModels/VSCodePageViewModel.cs
+++ b/WPILibInstaller-Avalonia/ViewModels/VSCodePageViewModel.cs
@@ -16,15 +16,16 @@ namespace WPILibInstaller.ViewModels
 {
     public class VSCodePageViewModel : PageViewModelBase, IVsCodeInstallLocationProvider
     {
-        private string baseInstallText = @"
+        private readonly string baseInstallText = @"
 For licensing reasons, VS Code cannot be included in the WPILib Installer. WPILib installs it's own copy of VS Code every year, not shared between years or a system install. If you have already installed VS Code for the current year, the Next button will be enabled and you can skip this step, otherwise choose from the following options. VS Code will be installed on this system using the installer selected here in later steps.
 
 1. Download VS Code for Single Install: Use this if you don't plan on sharing the VS Code installer between systems. This will be the fastest download.
 2. Use Downloaded Offline Installer: Use this to select a installer zip file previously downloaded from this tool.
 3. Download VS Code for Offline Install: Use this to download VS Code installers for all platforms, which can be shared between systems for offline use.
 {0}";
-        private string vsCodeInstallText = "4. Skip installing VS Code. This will display a warning if a compatibible VS Code installation isn't detected.";
-        
+
+        private readonly string vsCodeInstallText = "4. Skip installing VS Code. This will display a warning if a compatibible VS Code installation isn't detected.";
+
         public string InstallText { get; }
 
         public override bool ForwardVisible => forwardVisible;
@@ -124,7 +125,7 @@ For licensing reasons, VS Code cannot be included in the WPILib Installer. WPILi
         private readonly IProgramWindow programWindow;
         private readonly IMainWindowViewModel refresher;
         private readonly IViewModelResolver viewModelResolver;
-        
+
         public bool DevMode { get; }
 
         public VSCodePageViewModel(IMainWindowViewModel mainRefresher, IProgramWindow programWindow, IConfigurationProvider modelProvider, IViewModelResolver viewModelResolver,
@@ -135,8 +136,6 @@ For licensing reasons, VS Code cannot be included in the WPILib Installer. WPILi
             DownloadSingleVsCode = buttonFactory.CreateCatchableButton(DownloadSingleVSCodeFunc);
             DownloadVsCode = buttonFactory.CreateCatchableButton(DownloadVsCodeFunc);
             SelectVsCode = buttonFactory.CreateCatchableButton(SelectVsCodeFunc);
-
-            
 
             DevMode = devModeChecker.DevMode;
             this.refresher = mainRefresher;

--- a/WPILibInstaller-Avalonia/Views/ConfigurationPage.xaml
+++ b/WPILibInstaller-Avalonia/Views/ConfigurationPage.xaml
@@ -6,10 +6,10 @@
              x:Class="WPILibInstaller.Views.ConfigurationPage">
   <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
     <TextBlock Margin="0,0,0,20" FontSize="20" FontWeight="Bold">Select the items you would like to install.</TextBlock>
-    <CheckBox FontSize="15" IsEnabled="{Binding CanInstallVsCode, Mode=OneWay}" IsChecked="{Binding InstallVsCode}">Visual Studio Code</CheckBox>
-    <CheckBox FontSize="15" IsChecked="{Binding Model.InstallCpp}">C++ Compiler</CheckBox>
-    <CheckBox FontSize="15" IsChecked="{Binding Model.InstallGradle}">Gradle</CheckBox>
-    <CheckBox FontSize="15" IsChecked="{Binding Model.InstallJDK}">Java JDK/JRE</CheckBox>
+    <CheckBox FontSize="15" IsVisible="{Binding DevMode}" IsEnabled="{Binding CanInstallVsCode, Mode=OneWay}" IsChecked="{Binding InstallVsCode}">Visual Studio Code</CheckBox>
+    <CheckBox FontSize="15" IsVisible="{Binding DevMode}" IsChecked="{Binding Model.InstallCpp}">C++ Compiler</CheckBox>
+    <CheckBox FontSize="15" IsVisible="{Binding DevMode}" IsChecked="{Binding Model.InstallGradle}">Gradle</CheckBox>
+    <CheckBox FontSize="15" IsVisible="{Binding DevMode}" IsChecked="{Binding Model.InstallJDK}">Java JDK/JRE</CheckBox>
     <CheckBox FontSize="15" IsChecked="{Binding Model.InstallTools}">Tools and Utilities</CheckBox>
     <CheckBox FontSize="15" IsChecked="{Binding Model.InstallWPILibDeps}">WPILib Dependencies</CheckBox>
     <CheckBox FontSize="15" IsEnabled="{Binding CanInstallExtensions, Mode=OneWay}" IsChecked="{Binding Model.InstallVsCodeExtensions}">Visual Studio Code Extensions</CheckBox>

--- a/WPILibInstaller-Avalonia/Views/ConfigurationPage.xaml
+++ b/WPILibInstaller-Avalonia/Views/ConfigurationPage.xaml
@@ -10,9 +10,9 @@
     <CheckBox FontSize="15" IsVisible="{Binding DevMode}" IsChecked="{Binding Model.InstallCpp}">C++ Compiler</CheckBox>
     <CheckBox FontSize="15" IsVisible="{Binding DevMode}" IsChecked="{Binding Model.InstallGradle}">Gradle</CheckBox>
     <CheckBox FontSize="15" IsVisible="{Binding DevMode}" IsChecked="{Binding Model.InstallJDK}">Java JDK/JRE</CheckBox>
-    <CheckBox FontSize="15" IsChecked="{Binding Model.InstallTools}">Tools and Utilities</CheckBox>
-    <CheckBox FontSize="15" IsChecked="{Binding Model.InstallWPILibDeps}">WPILib Dependencies</CheckBox>
-    <CheckBox FontSize="15" IsEnabled="{Binding CanInstallExtensions, Mode=OneWay}" IsChecked="{Binding Model.InstallVsCodeExtensions}">Visual Studio Code Extensions</CheckBox>
+    <CheckBox FontSize="15" IsVisible="{Binding DevMode}" IsChecked="{Binding Model.InstallTools}">Tools and Utilities</CheckBox>
+    <CheckBox FontSize="15" IsVisible="{Binding DevMode}" IsChecked="{Binding Model.InstallWPILibDeps}">WPILib Dependencies</CheckBox>
+    <CheckBox FontSize="15" IsVisible="{Binding DevMode}" IsEnabled="{Binding CanInstallExtensions, Mode=OneWay}" IsChecked="{Binding Model.InstallVsCodeExtensions}">Visual Studio Code Extensions</CheckBox>
     <Grid Margin="0, 20, 0, 0">
       <Button HorizontalAlignment="Left" FontSize="15" Command="{Binding InstallLocalUser}" Padding="10">Install for this User</Button>
       <Button HorizontalAlignment="Right" FontSize="15" Padding="10" IsVisible="{Binding CanRunAsAdmin}" Command="{Binding InstallAdmin}">Install for all Users</Button>

--- a/WPILibInstaller-Avalonia/Views/StartPage.xaml
+++ b/WPILibInstaller-Avalonia/Views/StartPage.xaml
@@ -7,7 +7,7 @@
   <StackPanel HorizontalAlignment="Center"
               VerticalAlignment="Center">
     <Image Source="resm:WPILibInstaller.Assets.wpilib-128.png?assembly=WPILibInstaller"
-           Stretch="None"/>
+           Stretch="None" Name="WPILibImage"/>
     <TextBlock Text="Welcome to the WPILib Installer!"
                HorizontalAlignment="Center"
                FontWeight="Bold"

--- a/WPILibInstaller-Avalonia/Views/StartPage.xaml
+++ b/WPILibInstaller-Avalonia/Views/StartPage.xaml
@@ -17,6 +17,11 @@
                HorizontalAlignment="Center"
                FontSize="25"
                VerticalAlignment="Center" />
+    <TextBlock Text="Advanced Mode Enabled"
+               HorizontalAlignment="Center"
+               FontSize="20"
+               VerticalAlignment="Center"
+               IsVisible="{Binding DevMode}"/>
     <TextBlock Text="The artifacts and/or resource files were not found. Please click the buttons below to select them."
                IsVisible="{Binding MissingEitherFile}"/>
     <TextBlock Text="Verifying Artifacts File..."

--- a/WPILibInstaller-Avalonia/Views/StartPage.xaml.cs
+++ b/WPILibInstaller-Avalonia/Views/StartPage.xaml.cs
@@ -20,7 +20,7 @@ namespace WPILibInstaller.Views
         {
             AvaloniaXamlLoader.Load(this);
             Image wpilibImage = this.LogicalChildren[0].LogicalChildren.OfType<Image>().First();
-            wpilibImage.Tapped += (o, e) => 
+            wpilibImage.Tapped += (o, e) =>
             {
                 ((StartPageViewModel)this.DataContext!).LogoClicked(o, e);
             };

--- a/WPILibInstaller-Avalonia/Views/StartPage.xaml.cs
+++ b/WPILibInstaller-Avalonia/Views/StartPage.xaml.cs
@@ -20,8 +20,9 @@ namespace WPILibInstaller.Views
         {
             AvaloniaXamlLoader.Load(this);
             Image wpilibImage = this.LogicalChildren[0].LogicalChildren.OfType<Image>().First();
-            wpilibImage.Tapped += (o, e) => {
-              ((StartPageViewModel)this.DataContext!).LogoClicked(o, e);
+            wpilibImage.Tapped += (o, e) => 
+            {
+                ((StartPageViewModel)this.DataContext!).LogoClicked(o, e);
             };
         }
     }

--- a/WPILibInstaller-Avalonia/Views/StartPage.xaml.cs
+++ b/WPILibInstaller-Avalonia/Views/StartPage.xaml.cs
@@ -1,6 +1,11 @@
 ﻿using Avalonia.Markup.Xaml;
 using Avalonia.ReactiveUI;
+using Avalonia.Interactivity;
 using WPILibInstaller.ViewModels;
+using Avalonia.VisualTree;
+using System.Linq;
+using Avalonia.Controls;
+using System;
 
 namespace WPILibInstaller.Views
 {
@@ -14,6 +19,10 @@ namespace WPILibInstaller.Views
         private void InitializeComponent()
         {
             AvaloniaXamlLoader.Load(this);
+            Image wpilibImage = this.LogicalChildren[0].LogicalChildren.OfType<Image>().First();
+            wpilibImage.Tapped += (o, e) => {
+              ((StartPageViewModel)this.DataContext!).LogoClicked(o, e);
+            };
         }
     }
 }

--- a/WPILibInstaller-Avalonia/Views/VSCodePage.xaml
+++ b/WPILibInstaller-Avalonia/Views/VSCodePage.xaml
@@ -11,14 +11,7 @@
       <RowDefinition Height="3*"/>
     </Grid.RowDefinitions>
     <ScrollViewer Grid.Row="0" HorizontalScrollBarVisibility="Disabled">
-    <TextBlock TextWrapping="Wrap" FontSize="13">
-    For licensing reasons, VS Code cannot be included in the WPILib Installer. WPILib installs it's own copy of VS Code every year, not shared between years or a system install. If you have already installed VS Code for the current year, the Next button will be enabled and you can skip this step, otherwise choose from the following options. VS Code will be installed on this system using the installer selected here in later steps.
-
-    1. Download VS Code for Single Install: Use this if you don't plan on sharing the VS Code installer between systems. This will be the fastest download.
-    2. Skip installing VS Code. This will display a warning if a compatibible VS Code installation isn't detected.
-    3. Use Downloaded Offline Installer: Use this to select a installer zip file previously downloaded from this tool.
-    4. Download VS Code for Offline Install: Use this to download VS Code installers for all platforms, which can be shared between systems for offline use.
-    </TextBlock>
+    <TextBlock TextWrapping="Wrap" FontSize="13" Text="{Binding InstallText}"/>
     </ScrollViewer>
     <TextBlock TextWrapping="Wrap" Grid.Row="1" Height="15" FontWeight="Bold" FontSize="12" HorizontalAlignment="Center" VerticalAlignment="Center" Text="{Binding DoneText}"></TextBlock>
     <Grid Grid.Row="2">
@@ -32,7 +25,7 @@
         <ColumnDefinition Width="2*"/>
       </Grid.ColumnDefinitions>
       <Button Grid.Column="0" Grid.Row="0" Margin="0,0,5,5" IsEnabled="{Binding EnableSelectionButtons}" Content="Download VS Code for Single Install" Command="{Binding DownloadSingleVsCode}"></Button>
-      <Button Grid.Column="1" Grid.Row="0" Margin="5,0,0,5" IsEnabled="{Binding EnableSelectionButtons}" Content="Skip installing VS Code" Command="{Binding SkipVsCode}"></Button>
+      <Button Grid.Column="1" Grid.Row="0" Margin="5,0,0,5" IsVisible="{Binding DevMode}" IsEnabled="{Binding EnableSelectionButtons}" Content="Skip installing VS Code" Command="{Binding SkipVsCode}"></Button>
       <Button Grid.Column="0" Grid.Row="1" Margin="0,0,5,0" IsEnabled="{Binding EnableSelectionButtons}" Content="{Binding SelectText}" Command="{Binding SelectVsCode}"/>
       <Button Grid.Column="1" Grid.Row="1" Margin="5,0,0,0" IsEnabled="{Binding EnableSelectionButtons}" Content="{Binding DownloadText}" Command="{Binding DownloadVsCode}"/>
       <StackPanel Margin="5,0,0,0" Grid.Column="2" Grid.Row="0" Grid.RowSpan="2">


### PR DESCRIPTION
Generally, we don't want users to skip installing VS Code, or to configure any options other then the defaults. Users thinking they have the right stuff is the #1 cause for issues. So add a hidden dev mode, and without it activated disable all configuration options, and the ability to skip VS Code.

Closes #88 