### PR TITLE
Revert from .NET 6 to .NET 5

### DIFF
--- a/WPILibInstaller-Avalonia/WPILibInstaller-Avalonia.csproj
+++ b/WPILibInstaller-Avalonia/WPILibInstaller-Avalonia.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <AssemblyName>WPILibInstaller</AssemblyName>
     <RootNamespace>WPILibInstaller</RootNamespace>
     <ApplicationIcon>wpilib-256.ico</ApplicationIcon>

--- a/build.gradle
+++ b/build.gradle
@@ -215,13 +215,12 @@ def dotnetInstallerTask = tasks.register('createInstaller', Exec) {
     workingDir = "$projectDir/WPILibInstaller-Avalonia"
 
     if (project.hasProperty("macBuild")) {
-        commandLine 'dotnet', 'publish', '-c', 'Release', '-r', dotnetRuntime, '--self-contained',
+        commandLine 'dotnet', 'publish', '-c', 'Release', '-r', dotnetRuntime,
                 "/p:Version=$pubVersion", "/t:BundleApp", "-p:RuntimeIdentifier=osx-x64",
-                "-p:CFBundleShortVersionString=$pubVersion", "-p:CFBundleVersion=$pubVersion",
-                '/p:EnableCompressionInSingleFile=true'
+                "-p:CFBundleShortVersionString=$pubVersion", "-p:CFBundleVersion=$pubVersion"
     } else {
         commandLine 'dotnet', 'publish', '-c', 'Release', '-r', dotnetRuntime, '/p:PublishSingleFile=true',
-                 "/p:Version=$pubVersion", '/p:EnableCompressionInSingleFile=true', '--self-contained'
+                 "/p:Version=$pubVersion"
     }
 }
 


### PR DESCRIPTION
.NET 6 breaks Windows 7 support.