### PR TITLE
Abort install if a JDK process to be installed over is running

### DIFF
--- a/WPILibInstaller-Avalonia/ViewModels/InstallPageViewModel.cs
+++ b/WPILibInstaller-Avalonia/ViewModels/InstallPageViewModel.cs
@@ -470,7 +470,7 @@ namespace WPILibInstaller.ViewModels
                             }
                         }
                         return found;
-                    } 
+                    }
                     catch
                     {
                         // Do nothing. We don't want this code to break.

--- a/WPILibInstaller-Avalonia/ViewModels/InstallPageViewModel.cs
+++ b/WPILibInstaller-Avalonia/ViewModels/InstallPageViewModel.cs
@@ -435,6 +435,61 @@ namespace WPILibInstaller.ViewModels
         private async Task ExtractArchive(CancellationToken token, string[]? filter)
         {
             Progress = 0;
+            if (OperatingSystem.IsWindows())
+            {
+                Text = "Checking for currently running JDKs";
+                bool foundRunningExe = await Task.Run(() =>
+                {
+                    try
+                    {
+                        var jdkBinFolder = Path.Join(configurationProvider.InstallDirectory, configurationProvider.JdkConfig.Folder, "bin");
+                        var jdkExes = Directory.EnumerateFiles(jdkBinFolder, "*.exe", SearchOption.AllDirectories);
+                        bool found = false;
+                        foreach (var exe in jdkExes)
+                        {
+                            try
+                            {
+                                var name = Path.GetFileNameWithoutExtension(exe)!;
+                                var pNames = Process.GetProcessesByName(name);
+                                foreach (var p in pNames)
+                                {
+                                    if (p.MainModule?.FileName == exe)
+                                    {
+                                        found = true;
+                                        break;
+                                    }
+                                }
+                                if (found)
+                                {
+                                    break;
+                                }
+                            }
+                            catch
+                            {
+                                // Do nothing. We don't want this code to break.
+                            }
+                        }
+                        return found;
+                    } 
+                    catch
+                    {
+                        // Do nothing. We don't want this code to break.
+                        return false;
+                    }
+                });
+                if (foundRunningExe)
+                {
+                    string msg = "Running JDK processes have been found. Installation cannot continue. Please restart your computer, and rerun this installer without running thing else (including VS Code)";
+                    await MessageBox.Avalonia.MessageBoxManager.GetMessageBoxStandardWindow(new MessageBox.Avalonia.DTO.MessageBoxStandardParams
+                    {
+                        ContentTitle = "JDKs Running",
+                        ContentMessage = msg,
+                        Icon = MessageBox.Avalonia.Enums.Icon.Error,
+                        ButtonDefinitions = MessageBox.Avalonia.Enums.ButtonEnum.Ok
+                    }).ShowDialog(programWindow.Window);
+                    throw new InvalidOperationException(msg);
+                }
+            }
 
             var archive = configurationProvider.ZipArchive;
 


### PR DESCRIPTION
Closes #117 

In that issue, a slightly modified option 3 was chosen. It search for any exes running out of the JDK folder. If any are found, a popup is displayed telling the user to reboot.

Decided against killing processes, as its not reliable to do so. Also decided against detecting the jdks, as mid season updates can result in the MSVC runtimes changing without the JDK version changing. So we'd have to hash a bunch of files, and its probably not worth it.