### PR TITLE
Fix ScriptBase.py broken pipes causing application crash

### DIFF
--- a/files/ScriptBase.py
+++ b/files/ScriptBase.py
@@ -13,7 +13,9 @@ jdk_dir = os.path.join(os.path.dirname(jar_name), "..", "jdk", "bin", "java")
 
 try:
     p = subprocess.Popen(
-        [jdk_dir, "-jar", jar_name], stdout=subprocess.PIPE, stderr=subprocess.PIPE
+        [jdk_dir, "-jar", jar_name],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
     )
 except:
     # Start failed. Try JAVA_HOME.
@@ -25,8 +27,8 @@ except:
     try:
         p = subprocess.Popen(
             [jdk_dir, "-jar", jar_name],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
         )
     except Exception as e:
         # Really error


### PR DESCRIPTION
Python pipes the stdout and stderr of subprocesses into the Python
shell stdout and stderr. When the Python script exits, the pipes close,
writes to stdout and stderr fail in the application, and the application
throws an exception and exits.

By using /dev/null instead, the application will never attempt writing
to a broken pipe.