### PR TITLE
Make macOS VSCode universal instead of intel build

### DIFF
--- a/scripts/vscode.gradle
+++ b/scripts/vscode.gradle
@@ -13,7 +13,7 @@ def vscode64ZipName = "Windows64.zip".toString()
 def vscodeLinuxUrl = "https://update.code.visualstudio.com/${vsCodeVersion}/linux-x64/stable".toString()
 def vscodeLinuxZipName = "Linux.tar.gz"
 
-def vscodeMacUrl = "https://update.code.visualstudio.com/${vsCodeVersion}/darwin/stable".toString()
+def vscodeMacUrl = "https://update.code.visualstudio.com/${vsCodeVersion}/darwin-universal/stable".toString()
 def vscodeMacZipName = "Mac.zip"
 
 def cppWindowsUrl = 'https://github.com/Microsoft/vscode-cpptools/releases/download/1.7.1/cpptools-win32.vsix'


### PR DESCRIPTION
Change from downloading the intel chip build of VSCode on macOS to use the universal so rosseta is not when running WPILib VSCode.