### PR TITLE
Re-upgrade to .NET 6

### DIFF
--- a/WPILibInstaller-Avalonia/WPILibInstaller-Avalonia.csproj
+++ b/WPILibInstaller-Avalonia/WPILibInstaller-Avalonia.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>WPILibInstaller</AssemblyName>
     <RootNamespace>WPILibInstaller</RootNamespace>
     <ApplicationIcon>wpilib-256.ico</ApplicationIcon>

--- a/build.gradle
+++ b/build.gradle
@@ -215,12 +215,13 @@ def dotnetInstallerTask = tasks.register('createInstaller', Exec) {
     workingDir = "$projectDir/WPILibInstaller-Avalonia"
 
     if (project.hasProperty("macBuild")) {
-        commandLine 'dotnet', 'publish', '-c', 'Release', '-r', dotnetRuntime,
+        commandLine 'dotnet', 'publish', '-c', 'Release', '-r', dotnetRuntime, '--self-contained',
                 "/p:Version=$pubVersion", "/t:BundleApp", "-p:RuntimeIdentifier=osx-x64",
-                "-p:CFBundleShortVersionString=$pubVersion", "-p:CFBundleVersion=$pubVersion"
+                "-p:CFBundleShortVersionString=$pubVersion", "-p:CFBundleVersion=$pubVersion",
+                '/p:EnableCompressionInSingleFile=true'
     } else {
         commandLine 'dotnet', 'publish', '-c', 'Release', '-r', dotnetRuntime, '/p:PublishSingleFile=true',
-                 "/p:Version=$pubVersion"
+                 "/p:Version=$pubVersion", '/p:EnableCompressionInSingleFile=true', '--self-contained'
     }
 }
 


### PR DESCRIPTION
We are no longer supporting Windows 7 starting in 2023.

This reverts commit baa169fb5733b3ad836b17b727732c4f694c54c4.