### PR TITLE
Use --args for macOS open command

### DIFF
--- a/files/ScriptBaseCpp.py
+++ b/files/ScriptBaseCpp.py
@@ -13,7 +13,7 @@ if platform.system() == "Linux":
     exe_path, exe_name = os.path.split(exe_name)
     cmd = [os.path.join(exe_path, exe_name.lower())]
 elif platform.system() == "Darwin":
-    cmd = ["open", exe_name + ".app"]
+    cmd = ["open", exe_name + ".app", "--args"]
 elif platform.system() == "Windows":
     cmd = [exe_name + ".exe"]
 else:


### PR DESCRIPTION
Previously when using the Gradle open tool command (`gradle glass`) it would open the directory in finder and the tool. This was because it ran `open tool.app currentdirectory` so it opened both. `--args` passes it instead so it works. Tested on latest stable version of macOS.