### PR TITLE
Clean up file and version reads during build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -75,7 +75,7 @@ if (project.hasProperty('linuxBuild')) {
     project.ext.dotnetRuntime = 'win-x64'
 }
 
-ext.frcYear = '2023'
+apply from: 'scripts/versions.gradle'
 
 apply from: 'scripts/gradlew.gradle'
 apply from: 'scripts/installer.gradle'
@@ -218,14 +218,14 @@ def generateFullResourcesTask = tasks.register('generateFullResources', project.
 def dotnetInstallerTask = tasks.register('createInstaller', Exec) {
     workingDir = "$projectDir/WPILibInstaller-Avalonia"
 
-    if (project.hasProperty("macBuild")) {
+    def macRuntimeId = "osx-x64"
+    if (project.hasProperty("macBuildArm")) {
+        macRuntimeId = "osx-arm64"
+    }
+
+    if (project.hasProperty("macBuild") || project.hasProperty("macBuildArm")) {
         commandLine 'dotnet', 'publish', '-c', 'Release', '-r', dotnetRuntime, '--self-contained',
-                "/p:Version=$pubVersion", "/t:BundleApp", "-p:RuntimeIdentifier=osx-x64",
-                "-p:CFBundleShortVersionString=$pubVersion", "-p:CFBundleVersion=$pubVersion",
-                '/p:EnableCompressionInSingleFile=true'
-    } else if (project.hasProperty("macBuildArm")) {
-        commandLine 'dotnet', 'publish', '-c', 'Release', '-r', dotnetRuntime, '--self-contained',
-                "/p:Version=$pubVersion", "/t:BundleApp", "-p:RuntimeIdentifier=osx-arm64",
+                "/p:Version=$pubVersion", "/t:BundleApp", "-p:RuntimeIdentifier=${macRuntimeId}",
                 "-p:CFBundleShortVersionString=$pubVersion", "-p:CFBundleVersion=$pubVersion",
                 '/p:EnableCompressionInSingleFile=true'
     } else {
@@ -245,8 +245,12 @@ def versionFileTask = tasks.register('writeVersionNumber', Task) {
     }
 }
 
+def installerProj = new XmlParser().parse("$projectDir/WPILibInstaller-Avalonia/WPILibInstaller-Avalonia.csproj")
+
+def dotnetVersion = installerProj.PropertyGroup.TargetFramework.text()
+
 // Copies the main application to build/outputs.
-def installDirectory = "$projectDir/WPILibInstaller-Avalonia/bin/Release/net6.0/$dotnetRuntime/publish"
+def installDirectory = "$projectDir/WPILibInstaller-Avalonia/bin/Release/$dotnetVersion/$dotnetRuntime/publish"
 def macIcon = "$projectDir/WPILibInstaller-Avalonia/wpilib.icns"
 def copyInstallerFiles = tasks.register('copyInstallerFiles', Copy) {
     if (!project.hasProperty("macBuild") && !project.hasProperty("macBuildArm")) {

--- a/distwrapper/gradle-wrapper.properties
+++ b/distwrapper/gradle-wrapper.properties
@@ -1,5 +1,0 @@
-distributionBase=GRADLE_USER_HOME
-distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
-zipStoreBase=GRADLE_USER_HOME
-zipStorePath=wrapper/dists

--- a/scripts/gradlew.gradle
+++ b/scripts/gradlew.gradle
@@ -26,7 +26,7 @@ apply plugin: 'de.undercouch.download'
 
 def downloadGradle = tasks.register('downloadGradle', Download) {
   src gradleWrapperUrl
-  dest "$buildDir/downloads"
+  dest "$buildDir/downloads/gradlew"
   overwrite false
 }
 

--- a/scripts/gradlew.gradle
+++ b/scripts/gradlew.gradle
@@ -26,7 +26,7 @@ apply plugin: 'de.undercouch.download'
 
 def downloadGradle = tasks.register('downloadGradle', Download) {
   src gradleWrapperUrl
-  dest buildDir
+  dest "$buildDir/downloads"
   overwrite false
 }
 

--- a/scripts/gradlew.gradle
+++ b/scripts/gradlew.gradle
@@ -1,20 +1,20 @@
 import java.security.MessageDigest
 
-def props = new Properties()
-def propsFile = file("distwrapper/gradle-wrapper.properties")
-propsFile.withInputStream { props.load(it) }
+apply from: 'scripts/versions.gradle'
+
+def gradleWrapperUrl = "https://services.gradle.org/distributions/gradle-${gradleWrapperVersion}-bin.zip"
 
 ext.gradleConfigTaskSetup = {
 
   def wrapperTask = tasks.named('wrapper').get()
   return new Tuple2({ Task task ->
-    task.inputs.file propsFile
+    task.inputs.property 'wrapperUrl', gradleWrapperUrl
   }, { config ->
-    def distributionHash = new BigInteger(1, MessageDigest.getInstance("MD5").digest(props.distributionUrl.getBytes())).toString(36)
+    def distributionHash = new BigInteger(1, MessageDigest.getInstance("MD5").digest(gradleWrapperUrl.getBytes())).toString(36)
 
     def gradleCfg = [
         Hash: distributionHash,
-        ZipName: new File(props.distributionUrl).name,
+        ZipName: new File(gradleWrapperUrl).name,
         ExtractLocations: ['wrapper/dists', 'permwrapper/dists']
     ]
 
@@ -34,7 +34,7 @@ ext.gradleZipTaskSetup = { AbstractArchiveTask zip->
 
     zip.dependsOn downloadGradle
 
-    zip.from ("$buildDir/gradle-7.5.1-bin.zip") {
+    zip.from (downloadGradle.get().outputFiles.first()) {
         into '/installUtils'
     }
 }

--- a/scripts/gradlew.gradle
+++ b/scripts/gradlew.gradle
@@ -26,7 +26,8 @@ apply plugin: 'de.undercouch.download'
 
 def downloadGradle = tasks.register('downloadGradle', Download) {
   src gradleWrapperUrl
-  dest "$buildDir/downloads/gradlew"
+  def fileName = file(src.file).name
+  dest "$buildDir/downloads/$fileName"
   overwrite false
 }
 

--- a/scripts/gradlew.gradle
+++ b/scripts/gradlew.gradle
@@ -25,7 +25,7 @@ ext.gradleConfigTaskSetup = {
 apply plugin: 'de.undercouch.download'
 
 def downloadGradle = tasks.register('downloadGradle', Download) {
-  src props.distributionUrl
+  src gradleWrapperUrl
   dest buildDir
   overwrite false
 }

--- a/scripts/jdk.gradle
+++ b/scripts/jdk.gradle
@@ -2,39 +2,34 @@
 evaluationDependsOn(':gradleriobase')
 
 apply plugin: 'de.undercouch.download'
+apply from: 'scripts/versions.gradle'
 
+def jdkVersionUnderscore = jdkVersion.replace('+', '_')
+def jdkVersionEscaped = jdkVersion.replace('+', '%2B')
 
 def downloadLinuxJdk = tasks.register('downloadLinuxJdk', Download) {
-  src 'https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.4.1%2B1/OpenJDK17U-jdk_x64_linux_hotspot_17.0.4.1_1.tar.gz'
+  src "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-$jdkVersionEscaped/OpenJDK17U-jdk_x64_linux_hotspot_${jdkVersionUnderscore}.tar.gz"
   dest buildDir
   overwrite false
 }
-
-def jdkLinuxFile = file("$buildDir/OpenJDK17U-jdk_x64_linux_hotspot_17.0.4.1_1.tar.gz")
 
 def downloadMacJdk = tasks.register('downloadMacJdk', Download) {
-  src 'https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.4.1%2B1/OpenJDK17U-jdk_x64_mac_hotspot_17.0.4.1_1.tar.gz'
+  src "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-$jdkVersionEscaped/OpenJDK17U-jdk_x64_mac_hotspot_${jdkVersionUnderscore}.tar.gz"
   dest buildDir
   overwrite false
 }
-
-def jdkMacFile = file("$buildDir/OpenJDK17U-jdk_x64_mac_hotspot_17.0.4.1_1.tar.gz")
 
 def downloadMacArmJdk = tasks.register('downloadMacArmJdk', Download) {
-  src 'https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.4.1%2B1/OpenJDK17U-jdk_aarch64_mac_hotspot_17.0.4.1_1.tar.gz'
+  src "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-$jdkVersionEscaped/OpenJDK17U-jdk_aarch64_mac_hotspot_${jdkVersionUnderscore}.tar.gz"
   dest buildDir
   overwrite false
 }
-
-def jdkMacArmFile = file("$buildDir/OpenJDK17U-jdk_aarch64_mac_hotspot_17.0.4.1_1.tar.gz")
 
 def downloadWindowsJdk = tasks.register('downloadWindowsJdk', Download) {
-  src 'https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.4.1%2B1/OpenJDK17U-jdk_x64_windows_hotspot_17.0.4.1_1.zip'
+  src "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-$jdkVersionEscaped/OpenJDK17U-jdk_x64_windows_hotspot_${jdkVersionUnderscore}.zip"
   dest buildDir
   overwrite false
 }
-
-def jdkWindowsFile = file("$buildDir/OpenJDK17U-jdk_x64_windows_hotspot_17.0.4.1_1.zip")
 
 configurations {
   runtimex64
@@ -89,13 +84,13 @@ ext.jdkZipSetupWindows = { AbstractArchiveTask zip->
   zip.dependsOn jdkConfigFileTask
   zip.dependsOn runtimeExtractTask
 
-  zip.inputs.file jdkWindowsFile
+  zip.inputs.file downloadWindowsJdk.get().outputFiles.first()
   zip.inputs.file jdkConfigFile
 
-  zip.from(project.zipTree(jdkWindowsFile)) {
+  zip.from(project.zipTree(downloadWindowsJdk.get().outputFiles.first())) {
 
     eachFile { f->
-      f.path = f.path.replace('jdk-17.0.4.1+1/', 'jdk/')
+      f.path = f.path.replace("jdk-${jdkVersion}/", 'jdk/')
     }
 
     eachFile { f->
@@ -130,12 +125,12 @@ ext.jdkZipSetupLinux = { AbstractArchiveTask zip->
   zip.dependsOn downloadLinuxJdk
   zip.dependsOn jdkConfigFileTask
 
-  zip.inputs.file jdkLinuxFile
+  zip.inputs.file downloadLinuxJdk.get().outputFiles.first()
   zip.inputs.file jdkConfigFile
 
-  zip.from(project.tarTree(project.resources.gzip(jdkLinuxFile))) {
+  zip.from(project.tarTree(project.resources.gzip(downloadLinuxJdk.get().outputFiles.first()))) {
     eachFile { f->
-      f.path = f.path.replace('jdk-17.0.4.1+1/', 'jdk/')
+      f.path = f.path.replace("jdk-${jdkVersion}/", 'jdk/')
     }
 
     exclude '**/src.zip'
@@ -158,16 +153,16 @@ ext.jdkZipSetupMac = { AbstractArchiveTask zip->
   zip.dependsOn downloadMacJdk
   zip.dependsOn jdkConfigFileTask
 
-  zip.inputs.file jdkMacFile
+  zip.inputs.file downloadMacJdk.get().outputFiles.first()
   zip.inputs.file jdkConfigFile
 
-  zip.from(project.tarTree(project.resources.gzip(jdkMacFile))) {
+  zip.from(project.tarTree(project.resources.gzip(downloadMacJdk.get().outputFiles.first()))) {
     eachFile { f ->
-      f.path = f.path.replace('jdk-17.0.4.1+1/Contents/Home/', 'jdk/')
+      f.path = f.path.replace("jdk-${jdkVersion}/Contents/Home/", 'jdk/')
     }
 
-    exclude './jdk-17.0.4.1+1/Contents/MacOS/**'
-    exclude './jdk-17.0.4.1+1/Contents/Info.plist'
+    exclude "./jdk-${jdkVersion}/Contents/MacOS/**"
+    exclude "./jdk-${jdkVersion}/Contents/Info.plist"
 
     exclude '**/src.zip'
     exclude '**/bin/*.pdb'
@@ -189,16 +184,16 @@ ext.jdkZipSetupMacArm = { AbstractArchiveTask zip->
   zip.dependsOn downloadMacArmJdk
   zip.dependsOn jdkConfigFileTask
 
-  zip.inputs.file jdkMacArmFile
+  zip.inputs.file downloadMacArmJdk.get().outputFiles.first()
   zip.inputs.file jdkConfigFile
 
-  zip.from(project.tarTree(project.resources.gzip(jdkMacArmFile))) {
+  zip.from(project.tarTree(project.resources.gzip(downloadMacArmJdk.get().outputFiles.first()))) {
     eachFile { f ->
-      f.path = f.path.replace('jdk-17.0.4.1+1/Contents/Home/', 'jdk/')
+      f.path = f.path.replace("jdk-${jdkVersion}/Contents/Home/", 'jdk/')
     }
 
-    exclude './jdk-17.0.4.1+1/Contents/MacOS/**'
-    exclude './jdk-17.0.4.1+1/Contents/Info.plist'
+    exclude "./jdk-${jdkVersion}/Contents/MacOS/**"
+    exclude "./jdk-${jdkVersion}/Contents/Info.plist"
 
     exclude '**/src.zip'
     exclude '**/bin/*.pdb'

--- a/scripts/jdk.gradle
+++ b/scripts/jdk.gradle
@@ -84,7 +84,7 @@ ext.jdkZipSetupWindows = { AbstractArchiveTask zip->
   zip.dependsOn jdkConfigFileTask
   zip.dependsOn runtimeExtractTask
 
-  zip.inputs.file downloadWindowsJdk.get().outputFiles.first()
+  zip.inputs.files downloadWindowsJdk.get().outputFiles
   zip.inputs.file jdkConfigFile
 
   zip.from(project.zipTree(downloadWindowsJdk.get().outputFiles.first())) {
@@ -125,7 +125,7 @@ ext.jdkZipSetupLinux = { AbstractArchiveTask zip->
   zip.dependsOn downloadLinuxJdk
   zip.dependsOn jdkConfigFileTask
 
-  zip.inputs.file downloadLinuxJdk.get().outputFiles.first()
+  zip.inputs.files downloadLinuxJdk.get().outputFiles
   zip.inputs.file jdkConfigFile
 
   zip.from(project.tarTree(project.resources.gzip(downloadLinuxJdk.get().outputFiles.first()))) {
@@ -153,7 +153,7 @@ ext.jdkZipSetupMac = { AbstractArchiveTask zip->
   zip.dependsOn downloadMacJdk
   zip.dependsOn jdkConfigFileTask
 
-  zip.inputs.file downloadMacJdk.get().outputFiles.first()
+  zip.inputs.files downloadMacJdk.get().outputFiles
   zip.inputs.file jdkConfigFile
 
   zip.from(project.tarTree(project.resources.gzip(downloadMacJdk.get().outputFiles.first()))) {
@@ -184,7 +184,7 @@ ext.jdkZipSetupMacArm = { AbstractArchiveTask zip->
   zip.dependsOn downloadMacArmJdk
   zip.dependsOn jdkConfigFileTask
 
-  zip.inputs.file downloadMacArmJdk.get().outputFiles.first()
+  zip.inputs.files downloadMacArmJdk.get().outputFiles
   zip.inputs.file jdkConfigFile
 
   zip.from(project.tarTree(project.resources.gzip(downloadMacArmJdk.get().outputFiles.first()))) {

--- a/scripts/jdk.gradle
+++ b/scripts/jdk.gradle
@@ -9,25 +9,29 @@ def jdkVersionEscaped = jdkVersion.replace('+', '%2B')
 
 def downloadLinuxJdk = tasks.register('downloadLinuxJdk', Download) {
   src "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-$jdkVersionEscaped/OpenJDK17U-jdk_x64_linux_hotspot_${jdkVersionUnderscore}.tar.gz"
-  dest "$buildDir/downloads/jdkLinux"
+  def fileName = file(src.file).name
+  dest "$buildDir/downloads/$fileName"
   overwrite false
 }
 
 def downloadMacJdk = tasks.register('downloadMacJdk', Download) {
   src "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-$jdkVersionEscaped/OpenJDK17U-jdk_x64_mac_hotspot_${jdkVersionUnderscore}.tar.gz"
-  dest "$buildDir/downloads/jdkMac"
+  def fileName = file(src.file).name
+  dest "$buildDir/downloads/$fileName"
   overwrite false
 }
 
 def downloadMacArmJdk = tasks.register('downloadMacArmJdk', Download) {
   src "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-$jdkVersionEscaped/OpenJDK17U-jdk_aarch64_mac_hotspot_${jdkVersionUnderscore}.tar.gz"
-  dest "$buildDir/downloads/jdkMacArm"
+  def fileName = file(src.file).name
+  dest "$buildDir/downloads/$fileName"
   overwrite false
 }
 
 def downloadWindowsJdk = tasks.register('downloadWindowsJdk', Download) {
   src "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-$jdkVersionEscaped/OpenJDK17U-jdk_x64_windows_hotspot_${jdkVersionUnderscore}.zip"
-  dest "$buildDir/downloads/jdkWindows"
+  def fileName = file(src.file).name
+  dest "$buildDir/downloads/$fileName"
   overwrite false
 }
 

--- a/scripts/jdk.gradle
+++ b/scripts/jdk.gradle
@@ -9,25 +9,25 @@ def jdkVersionEscaped = jdkVersion.replace('+', '%2B')
 
 def downloadLinuxJdk = tasks.register('downloadLinuxJdk', Download) {
   src "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-$jdkVersionEscaped/OpenJDK17U-jdk_x64_linux_hotspot_${jdkVersionUnderscore}.tar.gz"
-  dest "$buildDir/downloads"
+  dest "$buildDir/downloads/jdkLinux"
   overwrite false
 }
 
 def downloadMacJdk = tasks.register('downloadMacJdk', Download) {
   src "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-$jdkVersionEscaped/OpenJDK17U-jdk_x64_mac_hotspot_${jdkVersionUnderscore}.tar.gz"
-  dest "$buildDir/downloads"
+  dest "$buildDir/downloads/jdkMac"
   overwrite false
 }
 
 def downloadMacArmJdk = tasks.register('downloadMacArmJdk', Download) {
   src "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-$jdkVersionEscaped/OpenJDK17U-jdk_aarch64_mac_hotspot_${jdkVersionUnderscore}.tar.gz"
-  dest "$buildDir/downloads"
+  dest "$buildDir/downloads/jdkMacArm"
   overwrite false
 }
 
 def downloadWindowsJdk = tasks.register('downloadWindowsJdk', Download) {
   src "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-$jdkVersionEscaped/OpenJDK17U-jdk_x64_windows_hotspot_${jdkVersionUnderscore}.zip"
-  dest "$buildDir/downloads"
+  dest "$buildDir/downloads/jdkWindows"
   overwrite false
 }
 

--- a/scripts/jdk.gradle
+++ b/scripts/jdk.gradle
@@ -9,25 +9,25 @@ def jdkVersionEscaped = jdkVersion.replace('+', '%2B')
 
 def downloadLinuxJdk = tasks.register('downloadLinuxJdk', Download) {
   src "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-$jdkVersionEscaped/OpenJDK17U-jdk_x64_linux_hotspot_${jdkVersionUnderscore}.tar.gz"
-  dest buildDir
+  dest "$buildDir/downloads"
   overwrite false
 }
 
 def downloadMacJdk = tasks.register('downloadMacJdk', Download) {
   src "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-$jdkVersionEscaped/OpenJDK17U-jdk_x64_mac_hotspot_${jdkVersionUnderscore}.tar.gz"
-  dest buildDir
+  dest "$buildDir/downloads"
   overwrite false
 }
 
 def downloadMacArmJdk = tasks.register('downloadMacArmJdk', Download) {
   src "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-$jdkVersionEscaped/OpenJDK17U-jdk_aarch64_mac_hotspot_${jdkVersionUnderscore}.tar.gz"
-  dest buildDir
+  dest "$buildDir/downloads"
   overwrite false
 }
 
 def downloadWindowsJdk = tasks.register('downloadWindowsJdk', Download) {
   src "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-$jdkVersionEscaped/OpenJDK17U-jdk_x64_windows_hotspot_${jdkVersionUnderscore}.zip"
-  dest buildDir
+  dest "$buildDir/downloads"
   overwrite false
 }
 

--- a/scripts/maven.gradle
+++ b/scripts/maven.gradle
@@ -173,8 +173,6 @@ def downloadReadTheDocs = tasks.register('downloadReadTheDocs', Download) {
   overwrite false
 }
 
-def rtdFile = file("$buildDir/frc-docs.zip")
-
 def downloadNewCommands = tasks.register('downloadNewCommands', Download) {
   src 'https://raw.githubusercontent.com/wpilibsuite/allwpilib/master/wpilibNewCommands/WPILibNewCommands.json'
   dest buildDir
@@ -191,7 +189,7 @@ ext.mavenZipSetup = { AbstractArchiveTask zip->
   zip.dependsOn downloadNewCommands
   zip.dependsOn downloadReadTheDocs
 
-  zip.from("$buildDir/WPILibNewCommands.json") {
+  zip.from(downloadNewCommands.get().outputFiles.first()) {
     into '/vendordeps'
   }
 
@@ -216,7 +214,7 @@ ext.mavenZipSetup = { AbstractArchiveTask zip->
     }
   }
 
-  zip.from(project.zipTree(rtdFile)) {
+  zip.from(project.zipTree(downloadReadTheDocs.get().outputFiles.first())) {
     into '/documentation/rtd'
   }
 }

--- a/scripts/maven.gradle
+++ b/scripts/maven.gradle
@@ -169,13 +169,15 @@ ext.mavenConfigSetup = {
 
 def downloadReadTheDocs = tasks.register('downloadReadTheDocs', Download) {
   src 'https://buildmedia.readthedocs.org/media/htmlzip/frc-docs/latest/frc-docs.zip'
-  dest "$buildDir/downloads/rtd"
+  def fileName = file(src.file).name
+  dest "$buildDir/downloads/$fileName"
   overwrite false
 }
 
 def downloadNewCommands = tasks.register('downloadNewCommands', Download) {
   src 'https://raw.githubusercontent.com/wpilibsuite/allwpilib/master/wpilibNewCommands/WPILibNewCommands.json'
-  dest "$buildDir/downloads/newCommands"
+  def fileName = file(src.file).name
+  dest "$buildDir/downloads/$fileName"
   overwrite false
 }
 

--- a/scripts/maven.gradle
+++ b/scripts/maven.gradle
@@ -169,13 +169,13 @@ ext.mavenConfigSetup = {
 
 def downloadReadTheDocs = tasks.register('downloadReadTheDocs', Download) {
   src 'https://buildmedia.readthedocs.org/media/htmlzip/frc-docs/latest/frc-docs.zip'
-  dest "$buildDir/downloads"
+  dest "$buildDir/downloads/rtd"
   overwrite false
 }
 
 def downloadNewCommands = tasks.register('downloadNewCommands', Download) {
   src 'https://raw.githubusercontent.com/wpilibsuite/allwpilib/master/wpilibNewCommands/WPILibNewCommands.json'
-  dest "$buildDir/downloads"
+  dest "$buildDir/downloads/newCommands"
   overwrite false
 }
 

--- a/scripts/maven.gradle
+++ b/scripts/maven.gradle
@@ -169,13 +169,13 @@ ext.mavenConfigSetup = {
 
 def downloadReadTheDocs = tasks.register('downloadReadTheDocs', Download) {
   src 'https://buildmedia.readthedocs.org/media/htmlzip/frc-docs/latest/frc-docs.zip'
-  dest buildDir
+  dest "$buildDir/downloads"
   overwrite false
 }
 
 def downloadNewCommands = tasks.register('downloadNewCommands', Download) {
   src 'https://raw.githubusercontent.com/wpilibsuite/allwpilib/master/wpilibNewCommands/WPILibNewCommands.json'
-  dest buildDir
+  dest "$buildDir/downloads"
   overwrite false
 }
 

--- a/scripts/toolchain.gradle
+++ b/scripts/toolchain.gradle
@@ -1,27 +1,22 @@
-def gitTag = 'v2023-4'
-def baseUrl = "https://github.com/wpilibsuite/opensdk/releases/download/$gitTag/"
+apply from: 'scripts/versions.gradle'
 
-def gccVersion = '12.1.0'
+def baseUrl = "https://github.com/wpilibsuite/opensdk/releases/download/$toolchainGitTag/"
 
 def fileNameWindows = "cortexa9_vfpv3-roborio-academic-2023-x86_64-w64-mingw32-Toolchain-${gccVersion}.zip"
 
 def downloadUrlWindows = baseUrl + fileNameWindows
-def fileWindows = file("$buildDir/$fileNameWindows")
 
 def fileNameMac = "cortexa9_vfpv3-roborio-academic-2023-x86_64-apple-darwin-Toolchain-${gccVersion}.tgz"
 
 def downloadUrlMac = baseUrl + fileNameMac
-def fileMac = file("$buildDir/$fileNameMac")
 
 def fileNameMacArm = "cortexa9_vfpv3-roborio-academic-2023-arm64-apple-darwin-Toolchain-${gccVersion}.tgz"
 
 def downloadUrlMacArm = baseUrl + fileNameMacArm
-def fileMacArm = file("$buildDir/$fileNameMacArm")
 
 def fileNameLinux = "cortexa9_vfpv3-roborio-academic-2023-x86_64-linux-gnu-Toolchain-${gccVersion}.tgz"
 
 def downloadUrlLinux = baseUrl + fileNameLinux
-def fileLinux = file("$buildDir/$fileNameLinux")
 
 apply plugin: 'de.undercouch.download'
 
@@ -66,9 +61,9 @@ ext.toolchainZipSetup = { AbstractArchiveTask zip->
   if (project.hasProperty('linuxBuild')) {
     zip.dependsOn downloadTaskLinux
 
-    zip.inputs.file fileLinux
+    zip.inputs.file downloadTaskLinux.get().outputFiles.first()
 
-    zip.from(project.tarTree(project.resources.gzip(fileLinux))) {
+    zip.from(project.tarTree(project.resources.gzip(downloadTaskLinux.get().outputFiles.first()))) {
 
       eachFile { f->
         f.path = f.path.replace('roborio-academic/', 'roborio/')
@@ -80,9 +75,9 @@ ext.toolchainZipSetup = { AbstractArchiveTask zip->
   } else if (project.hasProperty('macBuild')) {
     zip.dependsOn downloadTaskMac
 
-    zip.inputs.file fileMac
+    zip.inputs.file downloadTaskMac.get().outputFiles.first()
 
-    zip.from(project.tarTree(project.resources.gzip(fileMac))) {
+    zip.from(project.tarTree(project.resources.gzip(downloadTaskMac.get().outputFiles.first()))) {
 
       eachFile { f->
         f.path = f.path.replace('roborio-academic/', 'roborio/')
@@ -93,9 +88,9 @@ ext.toolchainZipSetup = { AbstractArchiveTask zip->
   } else if (project.hasProperty('macBuildArm')) {
     zip.dependsOn downloadTaskMacArm
 
-    zip.inputs.file fileMacArm
+    zip.inputs.file downloadTaskMacArm.get().outputFiles.first()
 
-    zip.from(project.tarTree(project.resources.gzip(fileMacArm))) {
+    zip.from(project.tarTree(project.resources.gzip(downloadTaskMacArm.get().outputFiles.first()))) {
 
       eachFile { f->
         f.path = f.path.replace('roborio-academic/', 'roborio/')
@@ -106,9 +101,9 @@ ext.toolchainZipSetup = { AbstractArchiveTask zip->
   } else {
     zip.dependsOn downloadTaskWindows
 
-    zip.inputs.file fileWindows
+    zip.inputs.file downloadTaskWindows.get().outputFiles.first()
 
-    zip.from(project.zipTree(fileWindows)) {
+    zip.from(project.zipTree(downloadTaskWindows.get().outputFiles.first())) {
 
       eachFile { f->
         f.path = f.path.replace('roborio-academic/', 'roborio/')

--- a/scripts/toolchain.gradle
+++ b/scripts/toolchain.gradle
@@ -22,25 +22,25 @@ apply plugin: 'de.undercouch.download'
 
 def downloadTaskWindows = tasks.register('downloadToolchainWindows', Download) {
   src downloadUrlWindows
-  dest buildDir
+  dest "$buildDir/downloads"
   overwrite false
 }
 
 def downloadTaskMac = tasks.register('downloadToolchainMac', Download) {
   src downloadUrlMac
-  dest buildDir
+  dest "$buildDir/downloads"
   overwrite false
 }
 
 def downloadTaskMacArm = tasks.register('downloadToolchainMacArm', Download) {
   src downloadUrlMacArm
-  dest buildDir
+  dest "$buildDir/downloads"
   overwrite false
 }
 
 def downloadTaskLinux = tasks.register('downloadToolchainLinux', Download) {
   src downloadUrlLinux
-  dest buildDir
+  dest "$buildDir/downloads"
   overwrite false
 }
 

--- a/scripts/toolchain.gradle
+++ b/scripts/toolchain.gradle
@@ -22,25 +22,25 @@ apply plugin: 'de.undercouch.download'
 
 def downloadTaskWindows = tasks.register('downloadToolchainWindows', Download) {
   src downloadUrlWindows
-  dest "$buildDir/downloads"
+  dest "$buildDir/downloads/toolchainWindows"
   overwrite false
 }
 
 def downloadTaskMac = tasks.register('downloadToolchainMac', Download) {
   src downloadUrlMac
-  dest "$buildDir/downloads"
+  dest "$buildDir/downloads/toolchainMac"
   overwrite false
 }
 
 def downloadTaskMacArm = tasks.register('downloadToolchainMacArm', Download) {
   src downloadUrlMacArm
-  dest "$buildDir/downloads"
+  dest "$buildDir/downloads/toolchainMacArm"
   overwrite false
 }
 
 def downloadTaskLinux = tasks.register('downloadToolchainLinux', Download) {
   src downloadUrlLinux
-  dest "$buildDir/downloads"
+  dest "$buildDir/downloads/toolchainLinux"
   overwrite false
 }
 

--- a/scripts/toolchain.gradle
+++ b/scripts/toolchain.gradle
@@ -22,25 +22,29 @@ apply plugin: 'de.undercouch.download'
 
 def downloadTaskWindows = tasks.register('downloadToolchainWindows', Download) {
   src downloadUrlWindows
-  dest "$buildDir/downloads/toolchainWindows"
+  def fileName = file(src.file).name
+  dest "$buildDir/downloads/$fileName"
   overwrite false
 }
 
 def downloadTaskMac = tasks.register('downloadToolchainMac', Download) {
   src downloadUrlMac
-  dest "$buildDir/downloads/toolchainMac"
+  def fileName = file(src.file).name
+  dest "$buildDir/downloads/$fileName"
   overwrite false
 }
 
 def downloadTaskMacArm = tasks.register('downloadToolchainMacArm', Download) {
   src downloadUrlMacArm
-  dest "$buildDir/downloads/toolchainMacArm"
+  def fileName = file(src.file).name
+  dest "$buildDir/downloads/$fileName"
   overwrite false
 }
 
 def downloadTaskLinux = tasks.register('downloadToolchainLinux', Download) {
   src downloadUrlLinux
-  dest "$buildDir/downloads/toolchainLinux"
+  def fileName = file(src.file).name
+  dest "$buildDir/downloads/$fileName"
   overwrite false
 }
 

--- a/scripts/toolchain.gradle
+++ b/scripts/toolchain.gradle
@@ -61,7 +61,7 @@ ext.toolchainZipSetup = { AbstractArchiveTask zip->
   if (project.hasProperty('linuxBuild')) {
     zip.dependsOn downloadTaskLinux
 
-    zip.inputs.file downloadTaskLinux.get().outputFiles.first()
+    zip.inputs.files downloadTaskLinux.get().outputFiles
 
     zip.from(project.tarTree(project.resources.gzip(downloadTaskLinux.get().outputFiles.first()))) {
 
@@ -75,7 +75,7 @@ ext.toolchainZipSetup = { AbstractArchiveTask zip->
   } else if (project.hasProperty('macBuild')) {
     zip.dependsOn downloadTaskMac
 
-    zip.inputs.file downloadTaskMac.get().outputFiles.first()
+    zip.inputs.files downloadTaskMac.get().outputFiles
 
     zip.from(project.tarTree(project.resources.gzip(downloadTaskMac.get().outputFiles.first()))) {
 
@@ -88,7 +88,7 @@ ext.toolchainZipSetup = { AbstractArchiveTask zip->
   } else if (project.hasProperty('macBuildArm')) {
     zip.dependsOn downloadTaskMacArm
 
-    zip.inputs.file downloadTaskMacArm.get().outputFiles.first()
+    zip.inputs.files downloadTaskMacArm.get().outputFiles
 
     zip.from(project.tarTree(project.resources.gzip(downloadTaskMacArm.get().outputFiles.first()))) {
 
@@ -101,7 +101,7 @@ ext.toolchainZipSetup = { AbstractArchiveTask zip->
   } else {
     zip.dependsOn downloadTaskWindows
 
-    zip.inputs.file downloadTaskWindows.get().outputFiles.first()
+    zip.inputs.files downloadTaskWindows.get().outputFiles
 
     zip.from(project.zipTree(downloadTaskWindows.get().outputFiles.first())) {
 

--- a/scripts/versions.gradle
+++ b/scripts/versions.gradle
@@ -1,0 +1,16 @@
+ext.vsCodeVersion = '1.72.1'
+ext.cppToolsVersion = '1.12.4'
+ext.javaExtVersion = '1.11.0'
+ext.javaDebugVersion = '0.45.0'
+ext.javaDependencyVersion = '0.21.0'
+
+ext.wpilibVersion = gradleRioVersion
+
+ext.gccVersion = '12.1.0'
+ext.toolchainGitTag = 'v2023-4'
+
+ext.jdkVersion = '17.0.4.1+1'
+
+ext.frcYear = '2023'
+
+ext.gradleWrapperVersion = '7.5.1'

--- a/scripts/vscode.gradle
+++ b/scripts/vscode.gradle
@@ -34,7 +34,7 @@ def javaDepUrl = "https://github.com/microsoft/vscode-java-dependency/releases/d
 
 def wpilibExtensionDownload = tasks.register("wpilibExtensionDownload", Download) {
   src wpilibExtensionUrl
-  dest "$buildDir/downloads"
+  dest "$buildDir/downloads/wpilibExt"
   overwrite false
 }
 
@@ -47,45 +47,45 @@ def standaloneDownload = tasks.register("standaloneDownload", Download) {
   } else {
     src wpilibUtilWinUrl
   }
-  dest "$buildDir/downloads"
+  dest "$buildDir/downloads/standalone"
   overwrite false
 }
 
 def cppExtensionDownload = tasks.register("cppExtensionDownload", Download) {
   src cppWindowsUrl
-  dest "$buildDir/downloads"
+  dest "$buildDir/downloads/cppWindows"
   overwrite false
 }
 
 def cppMacExtensionDownload = tasks.register("cppMacExtensionDownload", Download) {
   src cppMacUrl
-  dest "$buildDir/downloads"
+  dest "$buildDir/downloads/cppMac"
   overwrite false
 }
 
 def cppLinuxExtensionDownload = tasks.register("cppLinuxExtensionDownload", Download) {
   src cppLinuxUrl
-  dest "$buildDir/downloads"
+  dest "$buildDir/downloads/cppLinux"
   overwrite false
 }
 
 
 def javaLangExtensionDownload = tasks.register("javaLangExtensionDownload", Download) {
   src javaLangUrl
-  dest "$buildDir/downloads"
+  dest "$buildDir/downloads/javaLang"
   overwrite false
 }
 
 
 def javaDebugExtensionDownload = tasks.register("javaDebugExtensionDownload", Download) {
   src javaDebugUrl
-  dest "$buildDir/downloads"
+  dest "$buildDir/downloads/javaDebug"
   overwrite false
 }
 
 def javaDepExtensionDownload = tasks.register("javaDepExtensionDownload", Download) {
   src javaDepUrl
-  dest "$buildDir/downloads"
+  dest "$buildDir/downloads/javaDep"
   overwrite false
 }
 

--- a/scripts/vscode.gradle
+++ b/scripts/vscode.gradle
@@ -1,147 +1,101 @@
+apply from: 'scripts/versions.gradle'
 
 def vscodeFile = file("$buildDir/vscodeConfig.json")
 
-def vsCodeVersion = '1.72.1'
-def cppToolsVersion = '1.12.4'
-def javaExtVersion = '1.11.0'
-def javaDebugVersion = '0.45.0'
-def javaDependencyVersion = '0.21.0'
-
-def wpilibVersion = gradleRioVersion
-
-def vscodeWindowsUrl = "https://update.code.visualstudio.com/${vsCodeVersion}/win32-x64-archive/stable".toString()
-def vscodeWindowsZipName = "Windows.zip".toString()
-
-def vscodeLinuxUrl = "https://update.code.visualstudio.com/${vsCodeVersion}/linux-x64/stable".toString()
+def vscodeWindowsZipName = "Windows.zip"
 def vscodeLinuxZipName = "Linux.tar.gz"
-
-def vscodeMacUrl = "https://update.code.visualstudio.com/${vsCodeVersion}/darwin-universal/stable".toString()
 def vscodeMacZipName = "Mac.zip"
 
+def vscodeWindowsUrl = "https://update.code.visualstudio.com/${vsCodeVersion}/win32-x64-archive/stable".toString()
+
+def vscodeLinuxUrl = "https://update.code.visualstudio.com/${vsCodeVersion}/linux-x64/stable".toString()
+
+def vscodeMacUrl = "https://update.code.visualstudio.com/${vsCodeVersion}/darwin-universal/stable".toString()
+
 def cppWindowsUrl = "https://github.com/Microsoft/vscode-cpptools/releases/download/v${cppToolsVersion}/cpptools-win64.vsix"
-def cppWindowsVsix = 'Cpp.vsix'
 
 def cppMacUrl = "https://github.com/Microsoft/vscode-cpptools/releases/download/v${cppToolsVersion}/cpptools-osx.vsix"
-def cppMacVsix = 'CppMac.vsix'
 
 def cppLinuxUrl = "https://github.com/Microsoft/vscode-cpptools/releases/download/v${cppToolsVersion}/cpptools-linux.vsix"
-def cppLinuxVsix = 'CppLinux.vsix'
 
 def wpilibExtensionUrl = "https://github.com/wpilibsuite/vscode-wpilib/releases/download/v${wpilibVersion}/vscode-wpilib-${wpilibVersion}.vsix"
-def wpilibExtensionVsix = 'WPILib.vsix'
 
 def wpilibUtilWinUrl = "https://github.com/wpilibsuite/vscode-wpilib/releases/download/v${wpilibVersion}/wpilibutility-windows.zip"
-def wpilibUtilWinZipName = 'utilitywin.zip'
 
 def wpilibUtilLinuxUrl = "https://github.com/wpilibsuite/vscode-wpilib/releases/download/v${wpilibVersion}/wpilibutility-linux.tar.gz"
-def wpilibUtilLinuxZipName = 'utilitylinux.tar.gz'
 
 def wpilibUtilMacUrl = "https://github.com/wpilibsuite/vscode-wpilib/releases/download/v${wpilibVersion}/wpilibutility-mac.tar.gz"
-def wpilibUtilMacZipName = 'utilitymac.tar.gz'
 
 def javaDebugUrl = "https://github.com/microsoft/vscode-java-debug/releases/download/${javaDebugVersion}/vscjava.vscode-java-debug-${javaDebugVersion}.vsix"
-def javaDebugVsix = 'JavaDebug.vsix'
 
 def javaLangUrl = "https://github.com/redhat-developer/vscode-java/releases/download/v${javaExtVersion}/java-${javaExtVersion}.vsix"
-def javaLangVsix = "JavaLang.vsix"
 
 def javaDepUrl = "https://github.com/microsoft/vscode-java-dependency/releases/download/${javaDependencyVersion}/vscjava.vscode-java-dependency-${javaDependencyVersion}.vsix"
-def javaDepVsix = "JavaDeps.vsix"
 
-def javaLangFile = file("$buildDir/$javaLangVsix")
-def javaDebugFile = file("$buildDir/$javaDebugVsix")
-def javaDepFile = file("$buildDir/$javaDepVsix")
-
-def cppFile
-def utilityFile
-if (project.hasProperty('linuxBuild')) {
-  cppFile = file("$buildDir/$cppLinuxVsix")
-  utilityFile = file("$buildDir/$wpilibUtilLinuxZipName")
-} else if (project.hasProperty('macBuild') || project.hasProperty('macBuildArm')) {
-  cppFile = file("$buildDir/$cppMacVsix")
-  utilityFile = file("$buildDir/$wpilibUtilMacZipName")
-} else {
-  cppFile = file("$buildDir/$cppWindowsVsix")
-  utilityFile = file("$buildDir/$wpilibUtilWinZipName")
+def wpilibExtensionDownload = tasks.register("wpilibExtensionDownload", Download) {
+  src wpilibExtensionUrl
+  dest buildDir
+  overwrite false
 }
 
-def wpilibFile
-def wpilibExtensionDownload
+def standaloneDownload = tasks.register("standaloneDownload", Download) {
 
-if (project.hasProperty('vscodeLoc')) {
-  wpilibFile = file(vscodeLoc)
-
-  wpilibExtensionDownload = tasks.register('wpilibExtensionDownload') {
-
+  if (project.hasProperty('linuxBuild')) {
+    src wpilibUtilLinuxUrl
+  } else if (project.hasProperty('macBuild') || project.hasProperty('macBuildArm')) {
+    src wpilibUtilMacUrl
+  } else {
+    src wpilibUtilWinUrl
   }
-} else {
-  wpilibFile = file("$buildDir/$wpilibExtensionVsix")
-
-  wpilibExtensionDownload = tasks.register("wpilibExtensionDownload", Download) {
-    src wpilibExtensionUrl
-    dest file("$buildDir/$wpilibExtensionVsix")
-    overwrite false
-  }
-}
-
-def standaloneDownload
-
-if (project.hasProperty('standaloneLoc')) {
-  utilityFile = file(standaloneLoc)
-  standaloneDownload = tasks.register('standaloneDownload') {
-
-  }
-} else {
-  standaloneDownload = tasks.register("standaloneDownload", Download) {
-
-    if (project.hasProperty('linuxBuild')) {
-      src wpilibUtilLinuxUrl
-    } else if (project.hasProperty('macBuild') || project.hasProperty('macBuildArm')) {
-      src wpilibUtilMacUrl
-    } else {
-      src wpilibUtilWinUrl
-    }
-    dest utilityFile
-    overwrite false
-  }
+  dest buildDir
+  overwrite false
 }
 
 def cppExtensionDownload = tasks.register("cppExtensionDownload", Download) {
   src cppWindowsUrl
-  dest file("$buildDir/$cppWindowsVsix")
+  dest buildDir
   overwrite false
 }
 
 def cppMacExtensionDownload = tasks.register("cppMacExtensionDownload", Download) {
   src cppMacUrl
-  dest file("$buildDir/$cppMacVsix")
+  dest buildDir
   overwrite false
 }
 
 def cppLinuxExtensionDownload = tasks.register("cppLinuxExtensionDownload", Download) {
   src cppLinuxUrl
-  dest file("$buildDir/$cppLinuxVsix")
+  dest buildDir
   overwrite false
 }
 
 
 def javaLangExtensionDownload = tasks.register("javaLangExtensionDownload", Download) {
   src javaLangUrl
-  dest file("$buildDir/$javaLangVsix")
+  dest buildDir
   overwrite false
 }
 
 
 def javaDebugExtensionDownload = tasks.register("javaDebugExtensionDownload", Download) {
   src javaDebugUrl
-  dest file("$buildDir/$javaDebugVsix")
+  dest buildDir
   overwrite false
 }
 
 def javaDepExtensionDownload = tasks.register("javaDepExtensionDownload", Download) {
   src javaDepUrl
-  dest file("$buildDir/$javaDepVsix")
+  dest buildDir
   overwrite false
+}
+
+def cppDownloadTask
+if (project.hasProperty('linuxBuild')) {
+  cppDownloadTask = cppLinuxExtensionDownload
+} else if (project.hasProperty('macBuild') || project.hasProperty('macBuildArm')) {
+  cppDownloadTask = cppMacExtensionDownload
+} else {
+  cppDownloadTask = cppExtensionDownload
 }
 
 def getInformationOfVsix = { vsix, map->
@@ -153,38 +107,36 @@ def getInformationOfVsix = { vsix, map->
 
 def vscodeTask = tasks.register('vscodeConfig', Task) {
   dependsOn wpilibExtensionDownload
-  dependsOn cppExtensionDownload
-  dependsOn cppMacExtensionDownload
-  dependsOn cppLinuxExtensionDownload
+  dependsOn cppDownloadTask
   dependsOn javaLangExtensionDownload
   dependsOn javaDebugExtensionDownload
   dependsOn javaDepExtensionDownload
 
-  inputs.file javaLangFile
-  inputs.file javaDebugFile
-  inputs.file cppFile
-  inputs.file wpilibFile
-  inputs.file javaDepFile
+  inputs.file wpilibExtensionDownload.get().outputFiles.first()
+  inputs.file cppDownloadTask.get().outputFiles.first()
+  inputs.file javaLangExtensionDownload.get().outputFiles.first()
+  inputs.file javaDebugExtensionDownload.get().outputFiles.first()
+  inputs.file javaDepExtensionDownload.get().outputFiles.first()
 
   doLast {
     def config = [:]
 
     def wpilibMap = [:]
-    wpilibMap['vsix'] = wpilibExtensionVsix
-    getInformationOfVsix(zipTree(wpilibFile), wpilibMap)
+    wpilibMap['vsix'] = wpilibExtensionDownload.get().outputFiles.first().name
+    getInformationOfVsix(zipTree(wpilibExtensionDownload.get().outputFiles.first()), wpilibMap)
     def cppMap = [:]
-    cppMap['vsix'] = cppWindowsVsix
-    getInformationOfVsix(zipTree(cppFile), cppMap)
+    cppMap['vsix'] = cppDownloadTask.get().outputFiles.first().name
+    getInformationOfVsix(zipTree(cppDownloadTask.get().outputFiles.first()), cppMap)
     def javaLangMap = [:]
-    javaLangMap['vsix'] = javaLangVsix
-    getInformationOfVsix(zipTree(javaLangFile), javaLangMap)
+    javaLangMap['vsix'] = javaLangExtensionDownload.get().outputFiles.first().name
+    getInformationOfVsix(zipTree(javaLangExtensionDownload.get().outputFiles.first()), javaLangMap)
     def javaDebugMap = [:]
-    javaDebugMap['vsix'] = javaDebugVsix
-    getInformationOfVsix(zipTree(javaDebugFile), javaDebugMap)
+    javaDebugMap['vsix'] = javaDebugExtensionDownload.get().outputFiles.first().name
+    getInformationOfVsix(zipTree(javaDebugExtensionDownload.get().outputFiles.first()), javaDebugMap)
 
     def javaDepMap = [:]
-    javaDepMap['vsix'] = javaDepVsix
-    getInformationOfVsix(zipTree(javaDepFile), javaDepMap)
+    javaDepMap['vsix'] = javaDepExtensionDownload.get().outputFiles.first().name
+    getInformationOfVsix(zipTree(javaDepExtensionDownload.get().outputFiles.first()), javaDepMap)
 
     config['VsCodeWindowsUrl'] = vscodeWindowsUrl
     config['VsCodeWindowsName'] = vscodeWindowsZipName
@@ -231,19 +183,19 @@ ext.vscodeZipSetup = { AbstractArchiveTask zip->
 
   if (project.hasProperty('linuxBuild')) {
     // Linux
-    zip.from(project.tarTree(project.resources.gzip(utilityFile))) {
+    zip.from(project.tarTree(project.resources.gzip(standaloneDownload.get().outputFiles.first()))) {
       into '/utility'
       includeEmptyDirs = false
     }
   } else if (project.hasProperty('macBuild') || project.hasProperty('macBuildArm')) {
     // Mac
     // Cannot extract, otherwise mac borks
-    zip.from (utilityFile) {
+    zip.from (standaloneDownload.get().outputFiles.first()) {
       into '/utility'
     }
   } else {
     // Windows
-    zip.from(project.zipTree(utilityFile)) {
+    zip.from(project.zipTree(standaloneDownload.get().outputFiles.first())) {
       into '/utility'
 
       includeEmptyDirs = false
@@ -254,20 +206,19 @@ ext.vscodeZipSetup = { AbstractArchiveTask zip->
     into '/installUtils'
   }
 
-  zip.from (javaLangFile) {
+  zip.from (javaLangExtensionDownload.get().outputFiles.first()) {
     into '/vsCodeExtensions'
   }
-  zip.from (javaDebugFile) {
+  zip.from (javaDebugExtensionDownload.get().outputFiles.first()) {
     into '/vsCodeExtensions'
   }
-  zip.from (cppFile) {
-    into '/vsCodeExtensions'
-    rename {cppWindowsVsix}
-  }
-  zip.from (wpilibFile) {
+  zip.from (cppDownloadTask.get().outputFiles.first()) {
     into '/vsCodeExtensions'
   }
-  zip.from (javaDepFile) {
+  zip.from (wpilibExtensionDownload.get().outputFiles.first()) {
+    into '/vsCodeExtensions'
+  }
+  zip.from (javaDepExtensionDownload.get().outputFiles.first()) {
     into '/vsCodeExtensions'
   }
 }

--- a/scripts/vscode.gradle
+++ b/scripts/vscode.gradle
@@ -112,11 +112,11 @@ def vscodeTask = tasks.register('vscodeConfig', Task) {
   dependsOn javaDebugExtensionDownload
   dependsOn javaDepExtensionDownload
 
-  inputs.file wpilibExtensionDownload.get().outputFiles.first()
-  inputs.file cppDownloadTask.get().outputFiles.first()
-  inputs.file javaLangExtensionDownload.get().outputFiles.first()
-  inputs.file javaDebugExtensionDownload.get().outputFiles.first()
-  inputs.file javaDepExtensionDownload.get().outputFiles.first()
+  inputs.files wpilibExtensionDownload.get().outputFiles
+  inputs.files cppDownloadTask.get().outputFiles
+  inputs.files javaLangExtensionDownload.get().outputFiles
+  inputs.files javaDebugExtensionDownload.get().outputFiles
+  inputs.files javaDepExtensionDownload.get().outputFiles
 
   doLast {
     def config = [:]

--- a/scripts/vscode.gradle
+++ b/scripts/vscode.gradle
@@ -34,7 +34,8 @@ def javaDepUrl = "https://github.com/microsoft/vscode-java-dependency/releases/d
 
 def wpilibExtensionDownload = tasks.register("wpilibExtensionDownload", Download) {
   src wpilibExtensionUrl
-  dest "$buildDir/downloads/wpilibExt"
+  def fileName = file(src.file).name
+  dest "$buildDir/downloads/$fileName"
   overwrite false
 }
 
@@ -47,45 +48,52 @@ def standaloneDownload = tasks.register("standaloneDownload", Download) {
   } else {
     src wpilibUtilWinUrl
   }
-  dest "$buildDir/downloads/standalone"
+  def fileName = file(src.file).name
+  dest "$buildDir/downloads/$fileName"
   overwrite false
 }
 
 def cppExtensionDownload = tasks.register("cppExtensionDownload", Download) {
   src cppWindowsUrl
-  dest "$buildDir/downloads/cppWindows"
+  def fileName = file(src.file).name
+  dest "$buildDir/downloads/$fileName"
   overwrite false
 }
 
 def cppMacExtensionDownload = tasks.register("cppMacExtensionDownload", Download) {
   src cppMacUrl
-  dest "$buildDir/downloads/cppMac"
+  def fileName = file(src.file).name
+  dest "$buildDir/downloads/$fileName"
   overwrite false
 }
 
 def cppLinuxExtensionDownload = tasks.register("cppLinuxExtensionDownload", Download) {
   src cppLinuxUrl
-  dest "$buildDir/downloads/cppLinux"
+  def fileName = file(src.file).name
+  dest "$buildDir/downloads/$fileName"
   overwrite false
 }
 
 
 def javaLangExtensionDownload = tasks.register("javaLangExtensionDownload", Download) {
   src javaLangUrl
-  dest "$buildDir/downloads/javaLang"
+  def fileName = file(src.file).name
+  dest "$buildDir/downloads/$fileName"
   overwrite false
 }
 
 
 def javaDebugExtensionDownload = tasks.register("javaDebugExtensionDownload", Download) {
   src javaDebugUrl
-  dest "$buildDir/downloads/javaDebug"
+  def fileName = file(src.file).name
+  dest "$buildDir/downloads/$fileName"
   overwrite false
 }
 
 def javaDepExtensionDownload = tasks.register("javaDepExtensionDownload", Download) {
   src javaDepUrl
-  dest "$buildDir/downloads/javaDep"
+  def fileName = file(src.file).name
+  dest "$buildDir/downloads/$fileName"
   overwrite false
 }
 

--- a/scripts/vscode.gradle
+++ b/scripts/vscode.gradle
@@ -34,7 +34,7 @@ def javaDepUrl = "https://github.com/microsoft/vscode-java-dependency/releases/d
 
 def wpilibExtensionDownload = tasks.register("wpilibExtensionDownload", Download) {
   src wpilibExtensionUrl
-  dest buildDir
+  dest "$buildDir/downloads"
   overwrite false
 }
 
@@ -47,45 +47,45 @@ def standaloneDownload = tasks.register("standaloneDownload", Download) {
   } else {
     src wpilibUtilWinUrl
   }
-  dest buildDir
+  dest "$buildDir/downloads"
   overwrite false
 }
 
 def cppExtensionDownload = tasks.register("cppExtensionDownload", Download) {
   src cppWindowsUrl
-  dest buildDir
+  dest "$buildDir/downloads"
   overwrite false
 }
 
 def cppMacExtensionDownload = tasks.register("cppMacExtensionDownload", Download) {
   src cppMacUrl
-  dest buildDir
+  dest "$buildDir/downloads"
   overwrite false
 }
 
 def cppLinuxExtensionDownload = tasks.register("cppLinuxExtensionDownload", Download) {
   src cppLinuxUrl
-  dest buildDir
+  dest "$buildDir/downloads"
   overwrite false
 }
 
 
 def javaLangExtensionDownload = tasks.register("javaLangExtensionDownload", Download) {
   src javaLangUrl
-  dest buildDir
+  dest "$buildDir/downloads"
   overwrite false
 }
 
 
 def javaDebugExtensionDownload = tasks.register("javaDebugExtensionDownload", Download) {
   src javaDebugUrl
-  dest buildDir
+  dest "$buildDir/downloads"
   overwrite false
 }
 
 def javaDepExtensionDownload = tasks.register("javaDepExtensionDownload", Download) {
   src javaDepUrl
-  dest buildDir
+  dest "$buildDir/downloads"
   overwrite false
 }
 


### PR DESCRIPTION
Currently, many things have version updates where we have to update in multiple places. All the versions we have to update are in multiple places as well. This change makes it so all changes are in a single versions.gradle file, and versions are parsed where they need to be so they only have to be written once.