### PR TITLE
Fix progress bar always 0 for main extraction

### DIFF
--- a/WPILibInstaller-Avalonia/Utils/ArchiveUtils.cs
+++ b/WPILibInstaller-Avalonia/Utils/ArchiveUtils.cs
@@ -26,11 +26,11 @@ namespace WPILibInstaller.Utils
             {
                 // Seek to end, grab size
                 stream.Seek(-4, SeekOrigin.End);
-                Span<int> intSpan = stackalloc int[1];
+                Span<uint> intSpan = stackalloc uint[1];
 
                 stream.Read(MemoryMarshal.AsBytes(intSpan));
 
-                int uncompressedSize = intSpan[0];
+                uint uncompressedSize = intSpan[0];
 
                 stream.Seek(0, SeekOrigin.Begin);
 

--- a/WPILibInstaller-Avalonia/Utils/IArchiveExtractor.cs
+++ b/WPILibInstaller-Avalonia/Utils/IArchiveExtractor.cs
@@ -8,7 +8,7 @@ namespace WPILibInstaller.Utils
     {
         bool MoveToNextEntry();
 
-        int TotalUncompressSize { get; }
+        long TotalUncompressSize { get; }
 
         string EntryKey { get; }
 

--- a/WPILibInstaller-Avalonia/Utils/TarArchiveExtractor.cs
+++ b/WPILibInstaller-Avalonia/Utils/TarArchiveExtractor.cs
@@ -12,7 +12,7 @@ namespace WPILibInstaller.Utils
         private readonly TarInputStream dataStream;
         private TarEntry currentEntry = null!;
 
-        public TarArchiveExtractor(Stream stream, int size)
+        public TarArchiveExtractor(Stream stream, long size)
         {
             TotalUncompressSize = size;
             var gzipStream = new GZipStream(stream, CompressionMode.Decompress);
@@ -20,7 +20,7 @@ namespace WPILibInstaller.Utils
             this.dataStream = new TarInputStream(gzipStream, Encoding.ASCII);
         }
 
-        public int TotalUncompressSize { get; }
+        public long TotalUncompressSize { get; }
 
         public string EntryKey => currentEntry.Name;
 

--- a/WPILibInstaller-Avalonia/Utils/ZipArchiveExtractor.cs
+++ b/WPILibInstaller-Avalonia/Utils/ZipArchiveExtractor.cs
@@ -18,7 +18,7 @@ namespace WPILibInstaller.Utils
             entries = archive.Entries.GetEnumerator();
         }
 
-        public int TotalUncompressSize { get; }
+        public long TotalUncompressSize { get; }
 
         public string EntryKey => entries.Current.FullName;
 


### PR DESCRIPTION
Closes #302 

Hopefully we never get an uncompressed size of > 4gb, or we'll have to switch to a new archiving format.