### PR TITLE
Treat ARM64 Windows like x64 Windows

### DIFF
--- a/WPILibInstaller-Avalonia/Utils/PlatformUtils.cs
+++ b/WPILibInstaller-Avalonia/Utils/PlatformUtils.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Runtime.InteropServices;
+﻿using System.Runtime.InteropServices;
 
 namespace WPILibInstaller.Utils
 {

--- a/WPILibInstaller-Avalonia/Utils/PlatformUtils.cs
+++ b/WPILibInstaller-Avalonia/Utils/PlatformUtils.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.InteropServices;
+﻿using System;
+using System.Runtime.InteropServices;
 
 namespace WPILibInstaller.Utils
 {
@@ -47,7 +48,11 @@ namespace WPILibInstaller.Utils
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                if (currentArch == Architecture.X64)
+                // Since this program ships with an x64 .NET runtime, if it is running on ARM64
+                // we can safely assume that x64 emulation is available and working. This means
+                // everything else (except kernel drivers) can run as x64 ("Win64" in the local
+                // Platform enum).
+                if (currentArch == Architecture.X64 || currentArch == Architecture.Arm64)
                 {
                     CurrentPlatform = Platform.Win64;
                 }


### PR DESCRIPTION
This change allows the installer to run successfully on Windows 11 on ARM by treating it as x64 Windows.

With the advent of x64 emulation on ARM64 (introduced in Windows 11), x64 usermode applications like Visual Studio Code
run unmodified on ARM64 Windows. This includes the entire IDE stack.

Without this change the installer fails with:

```
System.Collections.Generic.KeyNotFoundException: The given key 'Invalid' was not present in the dictionary.
   at System.Collections.Generic.Dictionary`2.get_Item(TKey key)
   at WPILibInstaller.ViewModels.VSCodePageViewModel.DownloadSingleVSCodeFunc() in D:\a\WPILibInstaller-Avalonia\WPILibInstaller-Avalonia\WPILibInstaller-Avalonia\ViewModels\VSCodePageViewModel.cs:line 329
```

On Windows 10 on ARM it will fail with an error about the architecture not being supported, which will lead the user back to the
documentation that clearly states it is not supported.