### PR TITLE
Run tool updater and maven fixer jars directly from the installer

### DIFF
--- a/WPILibInstaller-Avalonia/Models/UpgradeConfig.cs
+++ b/WPILibInstaller-Avalonia/Models/UpgradeConfig.cs
@@ -6,13 +6,13 @@ namespace WPILibInstaller.Models
     public class MavenConfig
     {
         public string Folder { get; set; }
-        public string MetaDataFixerExe { get; set; }
+        public string MetaDataFixerJar { get; set; }
     }
 
     public class ToolsConfig
     {
         public string Folder { get; set; }
-        public string UpdaterExe { get; set; }
+        public string UpdaterJar { get; set; }
     }
 
     public class UpgradeConfig

--- a/WPILibInstaller-Avalonia/ViewModels/InstallPageViewModel.cs
+++ b/WPILibInstaller-Avalonia/ViewModels/InstallPageViewModel.cs
@@ -604,6 +604,20 @@ namespace WPILibInstaller.ViewModels
             await Task.Yield();
         }
 
+        private static Task<bool> RunJavaJar(string installDir, string jar, int timeoutMs)
+        {
+            string java = Path.Join(installDir, "jdk", "bin", "java");
+            if (OperatingSystem.IsWindows()) {
+                java += ".exe";
+            }
+            ProcessStartInfo pstart = new ProcessStartInfo(java, $"-jar \"{jar}\"");
+            var p = Process.Start(pstart);
+            return Task.Run(() =>
+            {
+                return p!.WaitForExit(timeoutMs);
+            });
+        }
+
         private static Task<bool> RunScriptExecutable(string script, int timeoutMs, params string[] args)
         {
             ProcessStartInfo pstart = new ProcessStartInfo(script, string.Join(" ", args));
@@ -619,9 +633,10 @@ namespace WPILibInstaller.ViewModels
             Text = "Configuring Tools";
             Progress = 50;
 
-            await RunScriptExecutable(Path.Combine(configurationProvider.InstallDirectory,
+            await RunJavaJar(configurationProvider.InstallDirectory,
+                Path.Combine(configurationProvider.InstallDirectory,
                 configurationProvider.UpgradeConfig.Tools.Folder,
-                configurationProvider.UpgradeConfig.Tools.UpdaterExe), 5000, "silent");
+                configurationProvider.UpgradeConfig.Tools.UpdaterJar), 20000);
         }
 
         private async Task RunMavenMetaDataFixer()
@@ -629,12 +644,11 @@ namespace WPILibInstaller.ViewModels
             Text = "Fixing up maven metadata";
             Progress = 50;
 
-            await RunScriptExecutable(Path.Combine(configurationProvider.InstallDirectory,
+            await RunJavaJar(configurationProvider.InstallDirectory,
+                Path.Combine(configurationProvider.InstallDirectory,
                 configurationProvider.UpgradeConfig.Maven.Folder,
-                configurationProvider.UpgradeConfig.Maven.MetaDataFixerExe), 5000, "silent");
+                configurationProvider.UpgradeConfig.Maven.MetaDataFixerJar), 20000);
         }
-
-
 
         private async Task RunVsCodeExtensionsSetup()
         {

--- a/WPILibInstaller-Avalonia/ViewModels/InstallPageViewModel.cs
+++ b/WPILibInstaller-Avalonia/ViewModels/InstallPageViewModel.cs
@@ -607,7 +607,8 @@ namespace WPILibInstaller.ViewModels
         private static Task<bool> RunJavaJar(string installDir, string jar, int timeoutMs)
         {
             string java = Path.Join(installDir, "jdk", "bin", "java");
-            if (OperatingSystem.IsWindows()) {
+            if (OperatingSystem.IsWindows())
+            {
                 java += ".exe";
             }
             ProcessStartInfo pstart = new ProcessStartInfo(java, $"-jar \"{jar}\"");

--- a/scripts/maven.gradle
+++ b/scripts/maven.gradle
@@ -179,12 +179,7 @@ ext.mavenConfigSetup = {
   }, { config->
     config['Maven'] = [:]
     config['Maven']['Folder'] = 'maven'
-
-    if (project.ext.isUnix == true) {
-      config['Maven']['MetaDataFixerExe'] = 'MavenMetaDataFixer.py'
-    } else {
-      config['Maven']['MetaDataFixerExe'] = 'MavenMetaDataFixer.bat'
-    }
+    config['Maven']['MetaDataFixerJar'] = 'MavenMetaDataFixer.jar'
   })
 }
 

--- a/scripts/tools.gradle
+++ b/scripts/tools.gradle
@@ -61,11 +61,7 @@ ext.toolsConfig = {
   }, { config->
     def tools = [:]
     tools['Folder'] = toolsFolder
-    if (project.ext.isUnix == true) {
-      tools['UpdaterExe'] = 'ToolsUpdater.py'
-    } else {
-      tools['UpdaterExe'] = 'ToolsUpdater.bat'
-    }
+    tools['UpdaterJar'] = 'ToolsUpdater.jar'
     config['Tools'] = tools
   })
 }


### PR DESCRIPTION
Since we have all the info, its safe to do so. The python and bash scripts are not removed so users can easily run them manually if necessary