### PR TITLE
Use individual VSCode Zip Files

### DIFF
--- a/WPILibInstaller-Avalonia/ViewModels/VSCodePageViewModel.cs
+++ b/WPILibInstaller-Avalonia/ViewModels/VSCodePageViewModel.cs
@@ -318,7 +318,8 @@ namespace WPILibInstaller.ViewModels
                     Model.ToExtractArchive = OpenArchive(ms);
                 }
 
-                DoneText = $"Done Downloading. Press Next to continue";
+                DoneText = "Done Downloading. Press Next to continue";
+
                 EnableSelectionButtons = true;
                 SetLocalForwardVisible(true);
             }

--- a/scripts/vscode.gradle
+++ b/scripts/vscode.gradle
@@ -2,9 +2,9 @@ apply from: 'scripts/versions.gradle'
 
 def vscodeFile = file("$buildDir/vscodeConfig.json")
 
-def vscodeWindowsZipName = "Windows.zip"
-def vscodeLinuxZipName = "Linux.tar.gz"
-def vscodeMacZipName = "Mac.zip"
+def vscodeWindowsZipName = "VSCode-${vsCodeVersion}-Windows.zip".toString()
+def vscodeLinuxZipName = "VSCode-${vsCodeVersion}-Linux.tar.gz".toString()
+def vscodeMacZipName = "VSCode-${vsCodeVersion}-Mac.zip".toString()
 
 def vscodeWindowsUrl = "https://update.code.visualstudio.com/${vsCodeVersion}/win32-x64-archive/stable".toString()
 


### PR DESCRIPTION
Instead of combining all three platforms into one zip, download each individually. On selection, look for individual file instead of comibned zip.
The existing hash check ensures the correct one is chosen. 
Fixes #335. This allows the CSA tool to download the correct version and be used for installation.