### PR TITLE
Update VS Code settings.json for deprecations

### DIFF
--- a/WPILibInstaller-Avalonia/ViewModels/InstallPageViewModel.cs
+++ b/WPILibInstaller-Avalonia/ViewModels/InstallPageViewModel.cs
@@ -296,12 +296,11 @@ namespace WPILibInstaller.ViewModels
                 settingsJson = (JObject)JsonConvert.DeserializeObject(await File.ReadAllTextAsync(settingsFile))!;
             }
 
-            SetIfNotSet("java.home", Path.Combine(homePath, "jdk"), settingsJson);
+            SetIfNotSet("java.jdt.ls.java.home", Path.Combine(homePath, "jdk"), settingsJson);
             SetIfNotSet("extensions.autoUpdate", false, settingsJson);
             SetIfNotSet("extensions.autoCheckUpdates", false, settingsJson);
             SetIfNotSet("extensions.ignoreRecommendations", true, settingsJson);
-            SetIfNotSet("extensions.showRecommendationsOnlyOnDemand", false, settingsJson);
-            SetIfNotSet("update.channel", "none", settingsJson);
+            SetIfNotSet("update.mode", "none", settingsJson);
             SetIfNotSet("update.showReleaseNotes", false, settingsJson);
             SetIfNotSet("http.systemCertificates", false, settingsJson);
 


### PR DESCRIPTION
showRecommendationsOnlyOnDemand is duplicative of ignoreRecommendations update.channel changed to update.mode
java.home changed to java.jdt.ls.java.home

The java.home change also requires a change if the vscode extension to read the new name