### PR TITLE
Update to .net 8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 7.0.100
+          dotnet-version: 8.x
 
       - uses: actions/setup-java@v3
         with:
@@ -109,7 +109,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 7.0.100
+          dotnet-version: 8.x
       - uses: actions/setup-python@v4
         with:
           python-version: 3.8

--- a/WPILibInstaller-Avalonia/WPILibInstaller-Avalonia.csproj
+++ b/WPILibInstaller-Avalonia/WPILibInstaller-Avalonia.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>WPILibInstaller</AssemblyName>
     <RootNamespace>WPILibInstaller</RootNamespace>
     <ApplicationIcon>wpilib-256.ico</ApplicationIcon>
@@ -41,19 +41,19 @@
     <None Remove="Views\VSCodePage.xaml" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Autofac" Version="6.3.0" />
+    <PackageReference Include="Autofac" Version="7.1.0" />
 
-    <PackageReference Include="Avalonia" Version="0.10.18" Condition="!$([MSBuild]::IsOsPlatform('Linux'))" />
-    <PackageReference Include="Avalonia.Desktop" Version="0.10.18" Condition="!$([MSBuild]::IsOsPlatform('Linux'))" />
-    <PackageReference Include="Avalonia.ReactiveUI" Version="0.10.18" Condition="!$([MSBuild]::IsOsPlatform('Linux'))" />
+    <PackageReference Include="Avalonia" Version="0.10.22" Condition="!$([MSBuild]::IsOsPlatform('Linux'))" />
+    <PackageReference Include="Avalonia.Desktop" Version="0.10.22" Condition="!$([MSBuild]::IsOsPlatform('Linux'))" />
+    <PackageReference Include="Avalonia.ReactiveUI" Version="0.10.22" Condition="!$([MSBuild]::IsOsPlatform('Linux'))" />
 
     <PackageReference Include="Avalonia" Version="0.10.10" Condition="$([MSBuild]::IsOsPlatform('Linux'))" />
     <PackageReference Include="Avalonia.Desktop" Version="0.10.10" Condition="$([MSBuild]::IsOsPlatform('Linux'))" />
     <PackageReference Include="Avalonia.ReactiveUI" Version="0.10.10" Condition="$([MSBuild]::IsOsPlatform('Linux'))" />
 
     <PackageReference Include="MessageBox.Avalonia" Version="1.7.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
-    <PackageReference Include="SharpZipLib" Version="1.3.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="SharpZipLib" Version="1.4.2" />
     <PackageReference Include="Dotnet.Bundle" Version="0.9.13" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Currently pre-release, but will be released in November and is an LTS. .net 7 support ends in May 2024. 
Update non-breaking dependencies