### PR TITLE
Update for 2024.1.1-beta-1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-gradleRioVersion: 2024.0.0-alpha-1
+gradleRioVersion: 2024.1.1-beta-1

--- a/scripts/toolchain.gradle
+++ b/scripts/toolchain.gradle
@@ -2,19 +2,19 @@ apply from: 'scripts/versions.gradle'
 
 def baseUrl = "https://github.com/wpilibsuite/opensdk/releases/download/$toolchainGitTag/"
 
-def fileNameWindows = "cortexa9_vfpv3-roborio-academic-2023-x86_64-w64-mingw32-Toolchain-${gccVersion}.zip"
+def fileNameWindows = "cortexa9_vfpv3-roborio-academic-2024-x86_64-w64-mingw32-Toolchain-${gccVersion}.zip"
 
 def downloadUrlWindows = baseUrl + fileNameWindows
 
-def fileNameMac = "cortexa9_vfpv3-roborio-academic-2023-x86_64-apple-darwin-Toolchain-${gccVersion}.tgz"
+def fileNameMac = "cortexa9_vfpv3-roborio-academic-2024-x86_64-apple-darwin-Toolchain-${gccVersion}.tgz"
 
 def downloadUrlMac = baseUrl + fileNameMac
 
-def fileNameMacArm = "cortexa9_vfpv3-roborio-academic-2023-arm64-apple-darwin-Toolchain-${gccVersion}.tgz"
+def fileNameMacArm = "cortexa9_vfpv3-roborio-academic-2024-arm64-apple-darwin-Toolchain-${gccVersion}.tgz"
 
 def downloadUrlMacArm = baseUrl + fileNameMacArm
 
-def fileNameLinux = "cortexa9_vfpv3-roborio-academic-2023-x86_64-linux-gnu-Toolchain-${gccVersion}.tgz"
+def fileNameLinux = "cortexa9_vfpv3-roborio-academic-2024-x86_64-linux-gnu-Toolchain-${gccVersion}.tgz"
 
 def downloadUrlLinux = baseUrl + fileNameLinux
 

--- a/scripts/versions.gradle
+++ b/scripts/versions.gradle
@@ -1,21 +1,21 @@
-ext.vsCodeVersion = '1.81.1'
+ext.vsCodeVersion = '1.83.0'
 
-ext.vscodeLinuxHash = '4ea6b0aaed22474027dc2678c774461b4bc3df1fcfbd0c918554e173a4af7448'
-ext.vscodeMacHash = 'eb30358431d3446daa47a4c140a03886d9790f7387c7b1582a9701c45a943bc1'
-ext.vscodeWindowsHash = 'ee16984f65afc817ded76e8e8b874e058e4b62dc1804d3089735182c8cc0b07f'
+ext.vscodeLinuxHash = 'c90bb63bc0a94ec8a8da938464a32550d41a2c8c2a91c35ce59bb936a403cbab'
+ext.vscodeMacHash = '973ee7f811966d2759b2bd8239532015f5427101e089302bfc9a1459464803f3'
+ext.vscodeWindowsHash = '1ace9488c7d8c39157ef6760e8b2561dc1c9883e1227efab4e85644835ac0194'
 
-ext.cppToolsVersion = '1.17.3'
-ext.javaExtVersion = '1.21.0'
-ext.javaDebugVersion = '0.52.0'
-ext.javaDependencyVersion = '0.23.0'
+ext.cppToolsVersion = '1.17.5'
+ext.javaExtVersion = '1.23.0'
+ext.javaDebugVersion = '0.54.0'
+ext.javaDependencyVersion = '0.23.1'
 
 ext.wpilibVersion = gradleRioVersion
 
 ext.gccVersion = '12.1.0'
-ext.toolchainGitTag = 'v2023-7'
+ext.toolchainGitTag = 'v2024-1'
 
-ext.jdkVersion = '17.0.8+7'
+ext.jdkVersion = '17.0.8.1+1'
 
 ext.frcYear = '2024'
 
-ext.gradleWrapperVersion = '8.1'
+ext.gradleWrapperVersion = '8.4'

--- a/scripts/versions.gradle
+++ b/scripts/versions.gradle
@@ -6,7 +6,7 @@ ext.vscodeWindowsHash = '1ace9488c7d8c39157ef6760e8b2561dc1c9883e1227efab4e85644
 
 ext.cppToolsVersion = '1.17.5'
 ext.javaExtVersion = '1.23.0'
-ext.javaDebugVersion = '0.54.0'
+ext.javaDebugVersion = '0.52.0'
 ext.javaDependencyVersion = '0.23.1'
 
 ext.wpilibVersion = gradleRioVersion

--- a/scripts/versions.gradle
+++ b/scripts/versions.gradle
@@ -7,7 +7,7 @@ ext.vscodeWindowsHash = '1ace9488c7d8c39157ef6760e8b2561dc1c9883e1227efab4e85644
 ext.cppToolsVersion = '1.17.5'
 ext.javaExtVersion = '1.23.0'
 ext.javaDebugVersion = '0.52.0'
-ext.javaDependencyVersion = '0.23.1'
+ext.javaDependencyVersion = '0.23.0'
 
 ext.wpilibVersion = gradleRioVersion
 


### PR DESCRIPTION
Version bumps:
- vscode 1.83.0
- cpptools 1.17.5
- javaext 1.23.0
- ~javadebug 0.54.0~
- ~javadep 0.23.1~
- toolchain v2024-1
- jdk 17.0.8.1+1
- gradlewrapper 8.4