### PR TITLE
Install to SpecialFolder.UserProfile instead of Personal

### DIFF
--- a/WPILibInstaller-Avalonia/ViewModels/StartPageViewModel.cs
+++ b/WPILibInstaller-Avalonia/ViewModels/StartPageViewModel.cs
@@ -373,7 +373,7 @@ namespace WPILibInstaller.ViewModels
                     }
                     else
                     {
-                        publicFolder = Environment.GetFolderPath(Environment.SpecialFolder.Personal);
+                        publicFolder = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
                     }
                 }
                 return Path.Combine(publicFolder, "wpilib", UpgradeConfig.FrcYear);


### PR DESCRIPTION
.Net 8 changed the location of Environment.SpecialFolder.Personal from ~ to ~/Documents. This restores the old location
https://learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/8.0/getfolderpath-unix
Fixes wpilibsuite/2024Beta#3