### PR TITLE
Add GitHub upload with split zip files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,7 +118,7 @@ jobs:
         run: |
           md5sum zipfiles/*
           sha256sum zipfiles/*
-      - name: Upload to GitHub
+      - name: Upload to GitHub wpilibsuite/allwpilib
         if: |
           github.repository_owner == 'wpilibsuite' &&
           startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,10 +106,10 @@ jobs:
           startsWith(github.ref, 'refs/tags/v')
         run: |
           mkdir zipfiles
-          zip -0 -s 1500m -j "zipfiles/WPILib_Linux-${GITHUB_REF#refs/tags/v}" Linux/*
-          zip -0 -s 1500m -j "zipfiles/WPILib_Windows-${GITHUB_REF#refs/tags/v}" Win64/*
-          zip -0 -s 1500m -j "zipfiles/WPILib_macOS-Intel-${GITHUB_REF#refs/tags/v}" macOS/*
-          zip -0 -s 1500m -j "zipfiles/WPILib_macOS-Arm64-${GITHUB_REF#refs/tags/v}" macOSArm/*
+          zip -0 -s 1500m -j "zipfiles/WPILib_Linux-${GITHUB_REF#refs/tags/v}.zip" Linux/*
+          zip -0 -s 1500m -j "zipfiles/WPILib_Windows-${GITHUB_REF#refs/tags/v}.zip" Win64/*
+          zip -0 -s 1500m -j "zipfiles/WPILib_macOS-Intel-${GITHUB_REF#refs/tags/v}.zip" macOS/*
+          zip -0 -s 1500m -j "zipfiles/WPILib_macOS-Arm64-${GITHUB_REF#refs/tags/v}.zip" macOSArm/*
       - name: Print Zip Checksums
         run: |
           md5sum zipfiles/*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,7 +123,7 @@ jobs:
           github.repository_owner == 'wpilibsuite' &&
           startsWith(github.ref, 'refs/tags/v')
         run: |
-          if ( gh release view "${GITHUB_REF#refs/tags/}" 1> /dev/null ) ; then
+          if ( gh -R wpilibsuite/allwpilib release view "${GITHUB_REF#refs/tags/}" 1> /dev/null ) ; then
             gh -R wpilibsuite/allwpilib release upload --clobber "${GITHUB_REF#refs/tags/}" zipfiles/*
           else
             gh -R wpilibsuite/allwpilib release create -d "${GITHUB_REF#refs/tags/}" zipfiles/*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,6 @@ jobs:
         run: jfrog rt u "**/*" "installer/${GITHUB_REF#refs/tags/}/"
       - name: Zip and split for GitHub
         if: |
-          github.repository_owner == 'wpilibsuite' &&
           startsWith(github.ref, 'refs/tags/v')
         run: |
           mkdir zipfiles
@@ -111,18 +110,19 @@ jobs:
           zip -0 -s 1500m -j "zipfiles/WPILib_Windows-${GITHUB_REF#refs/tags/v}" Win64/*
           zip -0 -s 1500m -j "zipfiles/WPILib_macOS-Intel-${GITHUB_REF#refs/tags/v}" macOS/*
           zip -0 -s 1500m -j "zipfiles/WPILib_macOS-Arm64-${GITHUB_REF#refs/tags/v}" macOSArm/*
-      - name: Upload to GitHub wpilibsuite/allwpilib
+      - name: Print Zip Checksums
+        run: |
+          md5sum zipfiles/*
+          sha256sum zipfiles/*
+      - name: Upload to GitHub
         if: |
-          github.repository_owner == 'wpilibsuite' &&
           startsWith(github.ref, 'refs/tags/v')
         run: |
-          if ( gh -R wpilibsuite/allwpilib release view "${GITHUB_REF#refs/tags/}" 1> /dev/null ) ; then
-            gh -R wpilibsuite/allwpilib release upload --clobber "${GITHUB_REF#refs/tags/}" zipfiles/*
+          if ( gh release view "${GITHUB_REF#refs/tags/}" 1> /dev/null ) ; then
+            gh release upload --clobber "${GITHUB_REF#refs/tags/}" zipfiles/*
           else
-            gh -R wpilibsuite/allwpilib release create -d "${GITHUB_REF#refs/tags/}" zipfiles/*
+            gh release create -d "${GITHUB_REF#refs/tags/}" zipfiles/*
           fi
-        env:
-          GITHUB_TOKEN: ${{secrets.GH_ADMIN_TOKEN}}
 
   format:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,28 @@ jobs:
           github.repository_owner == 'wpilibsuite' &&
           startsWith(github.ref, 'refs/tags/v')
         run: jfrog rt u "**/*" "installer/${GITHUB_REF#refs/tags/}/"
+      - name: Zip and split for GitHub
+        if: |
+          github.repository_owner == 'wpilibsuite' &&
+          startsWith(github.ref, 'refs/tags/v')
+        run: |
+          mkdir zipfiles
+          zip -0 -s 1500m -j "zipfiles/WPILib_Linux-${GITHUB_REF#refs/tags/v}" Linux/*
+          zip -0 -s 1500m -j "zipfiles/WPILib_Windows-${GITHUB_REF#refs/tags/v}" Win64/*
+          zip -0 -s 1500m -j "zipfiles/WPILib_macOS-Intel-${GITHUB_REF#refs/tags/v}" macOS/*
+          zip -0 -s 1500m -j "zipfiles/WPILib_macOS-Arm64-${GITHUB_REF#refs/tags/v}" macOSArm/*
+      - name: Upload to GitHub wpilibsuite/allwpilib
+        if: |
+          github.repository_owner == 'wpilibsuite' &&
+          startsWith(github.ref, 'refs/tags/v')
+        run: |
+          if ( gh -R wpilibsuite/allwpilib release view "${GITHUB_REF#refs/tags/}" 1> /dev/null ) ; then
+            gh -R wpilibsuite/allwpilib release upload --clobber "${GITHUB_REF#refs/tags/}" zipfiles/*
+          else
+            gh -R wpilibsuite/allwpilib release create -d "${GITHUB_REF#refs/tags/}" zipfiles/*
+          fi
+        env:
+          GITHUB_TOKEN: ${{secrets.GH_ADMIN_TOKEN}}
 
   format:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,7 @@ jobs:
         run: jfrog rt u "**/*" "installer/${GITHUB_REF#refs/tags/}/"
       - name: Zip and split for GitHub
         if: |
+          github.repository_owner == 'wpilibsuite' &&
           startsWith(github.ref, 'refs/tags/v')
         run: |
           mkdir zipfiles
@@ -111,18 +112,24 @@ jobs:
           zip -0 -s 1500m -j "zipfiles/WPILib_macOS-Intel-${GITHUB_REF#refs/tags/v}.zip" macOS/*
           zip -0 -s 1500m -j "zipfiles/WPILib_macOS-Arm64-${GITHUB_REF#refs/tags/v}.zip" macOSArm/*
       - name: Print Zip Checksums
+        if: |
+          github.repository_owner == 'wpilibsuite' &&
+          startsWith(github.ref, 'refs/tags/v')
         run: |
           md5sum zipfiles/*
           sha256sum zipfiles/*
       - name: Upload to GitHub
         if: |
+          github.repository_owner == 'wpilibsuite' &&
           startsWith(github.ref, 'refs/tags/v')
         run: |
           if ( gh release view "${GITHUB_REF#refs/tags/}" 1> /dev/null ) ; then
-            gh release upload --clobber "${GITHUB_REF#refs/tags/}" zipfiles/*
+            gh -R wpilibsuite/allwpilib release upload --clobber "${GITHUB_REF#refs/tags/}" zipfiles/*
           else
-            gh release create -d "${GITHUB_REF#refs/tags/}" zipfiles/*
+            gh -R wpilibsuite/allwpilib release create -d "${GITHUB_REF#refs/tags/}" zipfiles/*
           fi
+        env:
+          GITHUB_TOKEN: ${{secrets.GH_ADMIN_TOKEN}}
 
   format:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Split the zip files at 1500 MB boundaries to fit within GitHub release file size 2 GB limit.

Windows Explorer (at least on Windows 11) supports unzip of split zip files.