### PR TITLE
Upgrade vscode to 1.85.0 and upgrade extensions

### DIFF
--- a/scripts/versions.gradle
+++ b/scripts/versions.gradle
@@ -1,13 +1,13 @@
-ext.vsCodeVersion = '1.84.0'
+ext.vsCodeVersion = '1.85.0'
 
-ext.vscodeLinuxHash = '8e868ea2f475e900fe5b59a3f459acb62ccc11c11eb07769173092c56f03bc07'
-ext.vscodeMacHash = '2a78c914ac9f063b55f6a6b47ce2a8c2b29abefaa5173091d6ee7d861d5c2872'
-ext.vscodeWindowsHash = '455f9467ae70369e6c265b7ea2fbe8b53c1f8e53298712ae5bd75f963d1a5652'
+ext.vscodeLinuxHash = 'ae2e6ddc22c32e7f865faa06a00d1711941dcf1db290794c6ed659d5a1413977'
+ext.vscodeMacHash = '5e95973b9e84b2843028e98d7865622191db4562ef6a8d0e402b3bb1c01663ac'
+ext.vscodeWindowsHash = '31170a98a417c70a54d0f83ee96067aafeaacfbbce317e080b619c1001f3b7a9'
 
-ext.cppToolsVersion = '1.17.5'
-ext.javaExtVersion = '1.23.0'
-ext.javaDebugVersion = '0.52.0'
-ext.javaDependencyVersion = '0.23.0'
+ext.cppToolsVersion = '1.19.1'
+ext.javaExtVersion = '1.26.2023120808'
+ext.javaDebugVersion = '0.55.0'
+ext.javaDependencyVersion = '0.23.2023120100'
 
 ext.wpilibVersion = gradleRioVersion
 

--- a/scripts/vscode.gradle
+++ b/scripts/vscode.gradle
@@ -12,13 +12,13 @@ def vscodeLinuxUrl = "https://update.code.visualstudio.com/${vsCodeVersion}/linu
 
 def vscodeMacUrl = "https://update.code.visualstudio.com/${vsCodeVersion}/darwin-universal/stable".toString()
 
-def cppWindowsUrl = "https://github.com/Microsoft/vscode-cpptools/releases/download/v${cppToolsVersion}/cpptools-win64.vsix"
+def cppWindowsUrl = "https://frcmaven.wpi.edu/api/download/vscode-extensions/ms-vscode/cpptools/ms-vscode.cpptools-${cppToolsVersion}@win32-x64.vsix"
 
-def cppMacUrl = "https://github.com/Microsoft/vscode-cpptools/releases/download/v${cppToolsVersion}/cpptools-osx.vsix"
+def cppMacUrl = "https://frcmaven.wpi.edu/api/download/vscode-extensions/ms-vscode/cpptools/ms-vscode.cpptools-${cppToolsVersion}@darwin-x64.vsix"
 
-def cppMacArmUrl = "https://github.com/Microsoft/vscode-cpptools/releases/download/v${cppToolsVersion}/cpptools-osx-arm64.vsix"
+def cppMacArmUrl = "https://frcmaven.wpi.edu/api/download/vscode-extensions/ms-vscode/cpptools/ms-vscode.cpptools-${cppToolsVersion}@darwin-arm64.vsix"
 
-def cppLinuxUrl = "https://github.com/Microsoft/vscode-cpptools/releases/download/v${cppToolsVersion}/cpptools-linux.vsix"
+def cppLinuxUrl = "https://frcmaven.wpi.edu/api/download/vscode-extensions/ms-vscode/cpptools/ms-vscode.cpptools-${cppToolsVersion}@linux-x64.vsix"
 
 def wpilibExtensionUrl = "https://github.com/wpilibsuite/vscode-wpilib/releases/download/v${wpilibVersion}/vscode-wpilib-${wpilibVersion}.vsix"
 
@@ -28,11 +28,11 @@ def wpilibUtilLinuxUrl = "https://github.com/wpilibsuite/vscode-wpilib/releases/
 
 def wpilibUtilMacUrl = "https://github.com/wpilibsuite/vscode-wpilib/releases/download/v${wpilibVersion}/wpilibutility-mac.tar.gz"
 
-def javaDebugUrl = "https://github.com/microsoft/vscode-java-debug/releases/download/${javaDebugVersion}/vscjava.vscode-java-debug-${javaDebugVersion}.vsix"
+def javaDebugUrl = "https://frcmaven.wpi.edu/api/download/vscode-extensions/vscjava/vscode-java-debug/vscjava.vscode-java-debug-${javaDebugVersion}.vsix"
 
-def javaLangUrl = "https://github.com/redhat-developer/vscode-java/releases/download/v${javaExtVersion}/java-${javaExtVersion}.vsix"
+def javaLangUrl = "https://frcmaven.wpi.edu/api/download/vscode-extensions/redhat/java/redhat.java-${javaExtVersion}.vsix"
 
-def javaDepUrl = "https://github.com/microsoft/vscode-java-dependency/releases/download/${javaDependencyVersion}/vscjava.vscode-java-dependency-${javaDependencyVersion}.vsix"
+def javaDepUrl = "https://frcmaven.wpi.edu/api/download/vscode-extensions/vscjava/vscode-java-dependency/vscjava.vscode-java-dependency-${javaDependencyVersion}.vsix"
 
 def vscodeWindowsDownload = tasks.register("vscodeWindowsDownload", Download) {
   src vscodeWindowsUrl


### PR DESCRIPTION
Extensions upgrades:
- cpptools 1.19.1
- java 1.26.2023120808
- java-debug 0.55.0
- java-dependency 0.23.2023120100

The vsix files are now downloaded from Artifactory.