### PR TITLE
Remove GitHub upload with split zip files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,35 +115,6 @@ jobs:
           RCLONE_CONFIG_S3_ENDPOINT: ${{ secrets.CLOUDFLARE_ENDPOINT }}
           RCLONE_CONFIG_S3_ACCESS_KEY_ID: ${{ secrets.CLOUDFLARE_ACCESS_KEY_ID }}
           RCLONE_CONFIG_S3_SECRET_ACCESS_KEY: ${{ secrets.CLOUDFLARE_SECRET_ACCESS_KEY }}
-      - name: Zip and split for GitHub
-        if: |
-          github.repository_owner == 'wpilibsuite' &&
-          startsWith(github.ref, 'refs/tags/v')
-        run: |
-          mkdir zipfiles
-          zip -0 -s 1500m -j "zipfiles/WPILib_Linux-${GITHUB_REF#refs/tags/v}.zip" Linux/*
-          zip -0 -s 1500m -j "zipfiles/WPILib_Windows-${GITHUB_REF#refs/tags/v}.zip" Win64/*
-          zip -0 -s 1500m -j "zipfiles/WPILib_macOS-Intel-${GITHUB_REF#refs/tags/v}.zip" macOS/*
-          zip -0 -s 1500m -j "zipfiles/WPILib_macOS-Arm64-${GITHUB_REF#refs/tags/v}.zip" macOSArm/*
-      - name: Print Zip Checksums
-        if: |
-          github.repository_owner == 'wpilibsuite' &&
-          startsWith(github.ref, 'refs/tags/v')
-        run: |
-          md5sum zipfiles/*
-          sha256sum zipfiles/*
-      - name: Upload to GitHub wpilibsuite/allwpilib
-        if: |
-          github.repository_owner == 'wpilibsuite' &&
-          startsWith(github.ref, 'refs/tags/v')
-        run: |
-          if ( gh -R wpilibsuite/allwpilib release view "${GITHUB_REF#refs/tags/}" 1> /dev/null ) ; then
-            gh -R wpilibsuite/allwpilib release upload --clobber "${GITHUB_REF#refs/tags/}" zipfiles/*
-          else
-            gh -R wpilibsuite/allwpilib release create -d "${GITHUB_REF#refs/tags/}" zipfiles/*
-          fi
-        env:
-          GITHUB_TOKEN: ${{secrets.GH_ADMIN_TOKEN}}
 
   format:
     runs-on: ubuntu-latest


### PR DESCRIPTION
These are much more difficult to use than the direct downloads and their existence is confusing to users.

This reverts commit 8debfeb2d006f19edeef46aaa6cb99cda5b6def8.