### PR TITLE
Add AdvantageScope to tools menu

### DIFF
--- a/apps/ToolsUpdater/src/main/java/Program.java
+++ b/apps/ToolsUpdater/src/main/java/Program.java
@@ -93,6 +93,27 @@ public class Program {
     }
   }
 
+  private static void installAdvantageScope(String toolsPath) {
+    if (SystemUtils.IS_OS_MAC) {
+      String arch = System.getProperty("os.arch");
+      boolean isArm = arch.equals("arm64") || arch.equals("aarch64");
+      String archiveFileName = "advantagescope-wpilib-mac-" +
+          (isArm ? "arm64" : "x64") +
+          ".tar.gz";
+      String advantageScopeFolder = Paths.get(new File(toolsPath).getParent(), "advantagescope").toString();
+      Path archivePath = Paths.get(advantageScopeFolder, archiveFileName);
+
+      try {
+        Runtime.getRuntime().exec(new String[] {
+            "tar", "-xzf", archivePath.toString(), "-C", advantageScopeFolder
+        }).waitFor();
+      } catch (IOException | InterruptedException e) {
+        System.out.println(e.toString());
+        e.printStackTrace();
+      }
+    }
+  }
+
   public static void main(String[] args) throws URISyntaxException, IOException {
     Gson gson = new Gson();
 
@@ -106,10 +127,14 @@ public class Program {
       ToolConfig[] tools = gson.fromJson(reader, ToolConfig[].class);
       Arrays.stream(tools).filter(x -> x.isValid()).forEach(tool -> {
         System.out.println("Installing " + tool.name);
-        if (tool.cpp) {
-          installCppTool(tool, toolsPath);
-        } else {
-          installJavaTool(tool, toolsPath);
+        if (tool.name.equals("AdvantageScope")) {
+          installAdvantageScope(toolsPath);
+        } else if (tool.artifact != null) {
+          if (tool.cpp) {
+            installCppTool(tool, toolsPath);
+          } else {
+            installJavaTool(tool, toolsPath);
+          }
         }
       });
     }

--- a/apps/ToolsUpdater/src/main/java/ToolConfig.java
+++ b/apps/ToolsUpdater/src/main/java/ToolConfig.java
@@ -5,6 +5,6 @@ public class ToolConfig {
   public Boolean cpp;
 
   public boolean isValid() {
-    return name != null && version != null && artifact != null;
+    return name != null && version != null;
   }
 }

--- a/files/AdvantageScope.py
+++ b/files/AdvantageScope.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+
+from __future__ import print_function
+import os
+import platform
+import subprocess
+import sys
+import json
+
+script_name = os.path.abspath(sys.argv[0])
+tools_folder = os.path.dirname(script_name)
+year_folder = os.path.dirname(tools_folder)
+
+if platform.system() == "Linux":
+    cmd = [year_folder + "/advantagescope/AdvantageScope (WPILib).AppImage"]
+elif platform.system() == "Darwin":
+    cmd = ["open", year_folder + "/advantagescope/AdvantageScope (WPILib).app"]
+elif platform.system() == "Windows":
+    cmd = [year_folder + "\\advantagescope\\AdvantageScope (WPILib).exe"]
+
+try:
+    subprocess.Popen(cmd)
+except Exception as e:
+    with open("/Users/jonah/wpilib/2024/test_err.txt", "w") as test:
+        test.write(str(e))
+    print("Error launching tool:")
+    print(e)
+    exit(1)

--- a/files/AdvantageScope.py
+++ b/files/AdvantageScope.py
@@ -21,8 +21,6 @@ elif platform.system() == "Windows":
 try:
     subprocess.Popen(cmd)
 except Exception as e:
-    with open("/Users/jonah/wpilib/2024/test_err.txt", "w") as test:
-        test.write(str(e))
     print("Error launching tool:")
     print(e)
     exit(1)

--- a/files/AdvantageScope.py
+++ b/files/AdvantageScope.py
@@ -5,7 +5,6 @@ import os
 import platform
 import subprocess
 import sys
-import json
 
 script_name = os.path.abspath(sys.argv[0])
 tools_folder = os.path.dirname(script_name)
@@ -18,8 +17,11 @@ elif platform.system() == "Darwin":
 elif platform.system() == "Windows":
     cmd = [year_folder + "\\advantagescope\\AdvantageScope (WPILib).exe"]
 
+env = os.environ.copy()
+del env["ELECTRON_RUN_AS_NODE"]
+
 try:
-    subprocess.Popen(cmd)
+    subprocess.Popen(cmd, env=env)
 except Exception as e:
     print("Error launching tool:")
     print(e)

--- a/files/AdvantageScope.vbs
+++ b/files/AdvantageScope.vbs
@@ -1,0 +1,53 @@
+'Create File System Object for working with directories
+Set fso = WScript.CreateObject("Scripting.FileSystemObject")
+
+'Get the folder of this script
+toolsFolder = fso.GetParentFolderName(WScript.ScriptFullName)
+
+'Get the full path to the exe
+fullExeName = fso.BuildPath(fso.GetParentFolderName(toolsFolder), "advantagescope", "AdvantageScope (WPILib).exe")
+
+shellScript = fullExeName
+
+'Create Shell Object
+Set objShell = WScript.CreateObject( "WScript.Shell" )
+If (WScript.Arguments.Count > 0) Then
+	If (WScript.Arguments(0) = "silent") Then
+		For I = 1 To WScript.Arguments.Count - 1
+			spacedArg = " """ & WScript.Arguments(I)
+			spacedArg = spacedArg & """"
+			shellScript = shellScript & spacedArg
+		Next
+	Else
+		For I = 0 To WScript.Arguments.Count - 1
+			spacedArg = " """ & WScript.Arguments(I)
+			spacedArg = spacedArg & """"
+			shellScript = shellScript & spacedArg
+		Next
+	End If
+End If
+dim runObject
+' Allow us to catch a script run failure
+On Error Resume Next
+Set runObj = objShell.Exec(shellScript)
+If Err.Number <> 0 Then
+	If WScript.Arguments.Count > 0 Then
+		If (WScript.Arguments(0) <> "silent") Then
+			WScript.Echo "Error Launching Tool" + vbCrLf + Err.Description
+		Else
+			WScript.StdOut.Write("Error Launching Tool")
+			WScript.StdOut.Write(Error.Description)
+		End If
+	Else
+		WScript.Echo "Error Launching Tool"  + vbCrLf + Err.Description
+	End If
+	Set runObj = Nothing
+	Set objShell = Nothing
+	Set fso = Nothing
+	WScript.Quit(1)
+End If
+
+Set runObj = Nothing
+Set objShell = Nothing
+Set fso = Nothing
+WScript.Quit(0)

--- a/files/AdvantageScope.vbs
+++ b/files/AdvantageScope.vbs
@@ -4,13 +4,20 @@ Set fso = WScript.CreateObject("Scripting.FileSystemObject")
 'Get the folder of this script
 toolsFolder = fso.GetParentFolderName(WScript.ScriptFullName)
 
+'Get the AdvantageScope folder
+toolsFolder = fso.GetParentFolderName(WScript.ScriptFullName)
+yearFolder = fso.GetParentFolderName(toolsFolder)
+advantageScopeFolder = fso.BuildPath(yearFolder, "advantagescope")
+
 'Get the full path to the exe
-fullExeName = fso.BuildPath(fso.GetParentFolderName(toolsFolder), "advantagescope", "AdvantageScope (WPILib).exe")
+fullExeName = fso.BuildPath(advantageScopeFolder, "AdvantageScope (WPILib).exe")
 
 shellScript = fullExeName
 
 'Create Shell Object
 Set objShell = WScript.CreateObject( "WScript.Shell" )
+Set objEnv = objShell.Environment("PROCESS")
+objEnv.Remove("ELECTRON_RUN_AS_NODE")
 If (WScript.Arguments.Count > 0) Then
 	If (WScript.Arguments(0) = "silent") Then
 		For I = 1 To WScript.Arguments.Count - 1

--- a/scripts/tools.gradle
+++ b/scripts/tools.gradle
@@ -5,6 +5,9 @@ def scriptBaseUnixFile = file("files/ScriptBase.py")
 def scriptBaseCppFile = file("files/ScriptBaseCpp.vbs")
 def scriptBaseCppUnixFile = file("files/ScriptBaseCpp.py")
 
+def advantageScopeScriptFile = file("files/AdvantageScope.vbs")
+def advantageScopeScriptUnixFile = file("files/AdvantageScope.py")
+
 def toolsJsonTask = tasks.register('toolsJson', Task) {
 
   dependsOn tasks.named('lazyModelEvaluation')
@@ -44,6 +47,11 @@ def toolsJsonTask = tasks.register('toolsJson', Task) {
       item['cpp'] = true
       config << item
     }
+
+    def advantageScopeItem = [:]
+    advantageScopeItem['name'] = "AdvantageScope"
+    advantageScopeItem['version'] = advantagescopeGitTag
+    config << advantageScopeItem
 
     def gbuilder = getGsonBuilder()
     gbuilder.setPrettyPrinting()
@@ -85,11 +93,20 @@ ext.toolsSetup = { AbstractArchiveTask zip->
     fileMode 0755
   }
 
-    zip.from (scriptBaseCppFile) {
+  zip.from (scriptBaseCppFile) {
     into '/tools'
   }
 
   zip.from (scriptBaseCppUnixFile) {
+    into '/tools'
+    fileMode 0755
+  }
+
+  zip.from (advantageScopeScriptFile) {
+    into '/tools'
+  }
+
+  zip.from (advantageScopeScriptUnixFile) {
     into '/tools'
     fileMode 0755
   }


### PR DESCRIPTION
Closes https://github.com/wpilibsuite/vscode-wpilib/issues/631 and https://github.com/wpilibsuite/2024Beta/issues/13. This also makes the [docs page](https://docs.wpilib.org/en/latest/docs/software/dashboards/advantagescope.html) accurate.

AdvantageScope isn't a Java or C++ tool, but I think this is a decent solution. It's added to "tools.json" with just a name and version, then there are separate scripts for launching it that don't use the existing base scripts (this requires custom handling anyway to remove an environment variable that VSCode sets by default). The app is extracted as part of the ToolsUpdater on macOS, which preserves the notarization correctly.