### PR TITLE
Disable VS-Code completion case matching

### DIFF
--- a/WPILibInstaller-Avalonia/ViewModels/InstallPageViewModel.cs
+++ b/WPILibInstaller-Avalonia/ViewModels/InstallPageViewModel.cs
@@ -312,6 +312,7 @@ namespace WPILibInstaller.ViewModels
             SetIfNotSet("update.mode", "none", settingsJson);
             SetIfNotSet("update.showReleaseNotes", false, settingsJson);
             SetIfNotSet("http.systemCertificates", false, settingsJson);
+            SetIfNotSet("java.completion.matchCase", "off", settingsJson);
 
             string os;
             string path_seperator;


### PR DESCRIPTION
This restores previous behavior. It was changed by redhat-developer/vscode-java#3142 
https://www.chiefdelphi.com/t/need-some-help-with-vs-code-autocomplete-features/451055