### PR TITLE
Disable CLI args for AdvantageScope on Windows

### DIFF
--- a/files/AdvantageScope.vbs
+++ b/files/AdvantageScope.vbs
@@ -18,21 +18,6 @@ shellScript = fullExeName
 Set objShell = WScript.CreateObject( "WScript.Shell" )
 Set objEnv = objShell.Environment("PROCESS")
 objEnv.Remove("ELECTRON_RUN_AS_NODE")
-If (WScript.Arguments.Count > 0) Then
-	If (WScript.Arguments(0) = "silent") Then
-		For I = 1 To WScript.Arguments.Count - 1
-			spacedArg = " """ & WScript.Arguments(I)
-			spacedArg = spacedArg & """"
-			shellScript = shellScript & spacedArg
-		Next
-	Else
-		For I = 0 To WScript.Arguments.Count - 1
-			spacedArg = " """ & WScript.Arguments(I)
-			spacedArg = spacedArg & """"
-			shellScript = shellScript & spacedArg
-		Next
-	End If
-End If
 dim runObject
 ' Allow us to catch a script run failure
 On Error Resume Next


### PR DESCRIPTION
AdvantageScope expects the first argument to be a log file to open, which is used when launching it from a file browser on Linux and Windows. The VSCode extension passes the tool storage folder in the workspace (which AdvantageScope doesn't use), producing an error message on Windows. This is fixed by not copying the arguments to the launch script, which is consistent with the Python version.

This is unrelated to the issue where AdvantageScope is slow to launch on Windows.