### PR TITLE
Run vscode without sandbox if user namespaces disabled

### DIFF
--- a/files/frccode
+++ b/files/frccode
@@ -1,4 +1,10 @@
 #!/usr/bin/env bash
 SCRIPT_PATH="$(dirname "$(realpath -s "$BASH_SOURCE[0]")")"
+SANDBOX_PATH="$(realpath "$(find "$SCRIPT_PATH/../vscode" -type f -name chrome-sandbox)")"
+CODE_PATH="$(realpath "$(find "$SCRIPT_PATH/../vscode" -type f -name code | grep bin)")"
 
-"$(realpath "$(find "$SCRIPT_PATH/../vscode" -type f -name code | grep bin)")" $@
+if [ "$(sysctl -n kernel.apparmor_restrict_unprivileged_userns)" -eq "0" ] || [ "$(stat -c "%U" "$SANDBOX_PATH")" == "root" ] || [ -f "/etc/apparmor.d/frccode" ]; then
+	"$CODE_PATH" $@
+else
+        "$CODE_PATH" --no-sandbox $@
+fi

--- a/files/frccode.AppArmor
+++ b/files/frccode.AppArmor
@@ -1,0 +1,12 @@
+# This profile allows everything and only exists to give the
+# application a name instead of having the label "unconfined"
+
+abi <abi/4.0>,
+include <tunables/global>
+
+profile frcvscode /home/**/wpilib/**/vscode/VSCode-linux-x64/code flags=(unconfined) {
+  userns,
+
+  # Site-specific additions and overrides. See local/README for details.
+  include if exists <local/frccode>
+}

--- a/scripts/vars.gradle
+++ b/scripts/vars.gradle
@@ -4,6 +4,7 @@ def varsfilesh = file("files/frcvars.sh")
 def codefile = file("files/frccode")
 def codefileCmd = file("files/frccode.cmd")
 def icoFile = file("files/wpilib-256.ico")
+def appArmorFile = file("files/frccode.AppArmor")
 
 def pathfolder = 'frccode'
 
@@ -22,6 +23,7 @@ ext.varsZipSetup = { AbstractArchiveTask zip->
   zip.inputs.file icoFile
   zip.inputs.file codefile
   zip.inputs.file codefileCmd
+  zip.inputs.file appArmorFile
 
   zip.from (varsfile) {
     into "/$pathfolder"
@@ -60,5 +62,12 @@ ext.varsZipSetup = { AbstractArchiveTask zip->
 
   zip.from (icoFile) {
     into "/$pathfolder"
+  }
+
+  zip.from (appArmorFile) {
+    into "/$pathfolder/AppArmor"
+    rename {
+      "frccode"
+    }
   }
 }


### PR DESCRIPTION
Allows VS Code to run on Ubuntu 24.04 without root
Also adds an AppArmor profile that a user could install if they have root