### PR TITLE
Fix icon in dock on Ubuntu 24.04

### DIFF
--- a/WPILibInstaller-Avalonia/ViewModels/InstallPageViewModel.cs
+++ b/WPILibInstaller-Avalonia/ViewModels/InstallPageViewModel.cs
@@ -905,6 +905,7 @@ Exec={configurationProvider.InstallDirectory}/frccode/frccode{frcYear}
 Icon={configurationProvider.InstallDirectory}/frccode/wpilib-256.ico
 Terminal=false
 StartupNotify=true
+StartupWMClass=Code
 ";
 
                 var desktopPath = Path.GetDirectoryName(desktopFile);


### PR DESCRIPTION
Since the .desktop file launches a script, Ubuntu 24.04 shows the generic script icon in the doc. 
This was adapted from https://ubuntuhandbook.org/index.php/2024/04/missing-icon-dock-ubuntu-2404/ 
This doesn't override the icon when system VS Code is installed, but uses the WPILib icon when system VS Code isn't installed