### PR TITLE
Fixes for AdvantageScope on Ubuntu

### DIFF
--- a/files/AdvantageScope.py
+++ b/files/AdvantageScope.py
@@ -11,7 +11,7 @@ tools_folder = os.path.dirname(script_name)
 year_folder = os.path.dirname(tools_folder)
 
 if platform.system() == "Linux":
-    cmd = [year_folder + "/advantagescope/AdvantageScope (WPILib).AppImage"]
+    cmd = [year_folder + "/advantagescope/advantagescope-wpilib"]
 elif platform.system() == "Darwin":
     cmd = ["open", year_folder + "/advantagescope/AdvantageScope (WPILib).app"]
 elif platform.system() == "Windows":

--- a/files/advantagescope.AppArmor
+++ b/files/advantagescope.AppArmor
@@ -4,7 +4,7 @@
 abi <abi/4.0>,
 include <tunables/global>
 
-profile advantagescope /home/**/wpilib/**/advantagescope/advantagescope flags=(unconfined) {
+profile advantagescope /home/**/wpilib/**/advantagescope/advantagescope-wpilib flags=(unconfined) {
   userns,
 
   # Site-specific additions and overrides. See local/README for details.

--- a/files/advantagescope.AppArmor
+++ b/files/advantagescope.AppArmor
@@ -1,0 +1,12 @@
+# This profile allows everything and only exists to give the
+# application a name instead of having the label "unconfined"
+
+abi <abi/4.0>,
+include <tunables/global>
+
+profile advantagescope /home/**/wpilib/**/advantagescope/advantagescope flags=(unconfined) {
+  userns,
+
+  # Site-specific additions and overrides. See local/README for details.
+  include if exists <local/advantagescope>
+}

--- a/scripts/vars.gradle
+++ b/scripts/vars.gradle
@@ -6,6 +6,7 @@ def codefileCmd = file("files/frccode.cmd")
 def icoFile = file("files/wpilib-256.ico")
 def codeAppArmorFile = file("files/frccode.AppArmor")
 def utilAppArmorFile = file("files/wpilibutility.AppArmor")
+def advantagescopeAppArmorFile = file("files/advantagescope.AppArmor")
 
 def pathfolder = 'frccode'
 
@@ -77,6 +78,13 @@ ext.varsZipSetup = { AbstractArchiveTask zip->
     into "/$pathfolder/AppArmor"
     rename {
       "wpilibutility"
+    }
+  }
+
+  zip.from (advantagescopeAppArmorFile) {
+    into "/$pathfolder/AppArmor"
+    rename {
+      "advantagescope"
     }
   }
 }


### PR DESCRIPTION
Related to #416.

- I switched the distribution method on Linux from AppImage to an unpacked zip (the way it already works on Windows). The next release of AdvantageScope will have assets with the new format.
- I added an AppArmor profile for AdvantageScope, though since it requires root to install I don't think it's feasible to do that automatically. At a minimum the documentation should probably be updated to describe how to install AppArmor profiles (including the VSCode and wpilibutility ones).