### PR TITLE
Only install files if they are used by a specific platform

### DIFF
--- a/scripts/tools.gradle
+++ b/scripts/tools.gradle
@@ -84,30 +84,32 @@ ext.toolsSetup = { AbstractArchiveTask zip->
     into '/tools'
   }
 
-  zip.from (scriptBaseFile) {
-    into '/tools'
-  }
+  if (project.ext.buildClassifier == 'Windows') {
+    zip.from (scriptBaseFile) {
+      into '/tools'
+    }
 
-  zip.from (scriptBaseUnixFile) {
-    into '/tools'
-    fileMode 0755
-  }
+    zip.from (scriptBaseCppFile) {
+      into '/tools'
+    }
 
-  zip.from (scriptBaseCppFile) {
-    into '/tools'
-  }
+    zip.from (advantageScopeScriptFile) {
+      into '/tools'
+    }
+  } else {
+    zip.from (scriptBaseUnixFile) {
+      into '/tools'
+      fileMode 0755
+    }
 
-  zip.from (scriptBaseCppUnixFile) {
-    into '/tools'
-    fileMode 0755
-  }
+    zip.from (scriptBaseCppUnixFile) {
+      into '/tools'
+      fileMode 0755
+    }
 
-  zip.from (advantageScopeScriptFile) {
-    into '/tools'
-  }
-
-  zip.from (advantageScopeScriptUnixFile) {
-    into '/tools'
-    fileMode 0755
+    zip.from (advantageScopeScriptUnixFile) {
+      into '/tools'
+      fileMode 0755
+    }
   }
 }

--- a/scripts/vars.gradle
+++ b/scripts/vars.gradle
@@ -28,38 +28,40 @@ ext.varsZipSetup = { AbstractArchiveTask zip->
   zip.inputs.file codeAppArmorFile
   zip.inputs.file utilAppArmorFile
 
-  zip.from (varsfile) {
-    into "/$pathfolder"
-    rename {
-      "frcvars${frcYear}.bat"
+  if (project.ext.buildClassifier == 'Windows') {
+    zip.from (varsfile) {
+      into "/$pathfolder"
+      rename {
+        "frcvars${frcYear}.bat"
+      }
     }
-  }
 
-  zip.from (varsfilePS) {
-    into "/$pathfolder"
-    rename {
-      "frcvars${frcYear}.ps1"
+    zip.from (varsfilePS) {
+      into "/$pathfolder"
+      rename {
+        "frcvars${frcYear}.ps1"
+      }
     }
-  }
 
-  zip.from (varsfilesh) {
-    into "/$pathfolder"
-    rename {
-      "frcvars${frcYear}.sh"
+    zip.from (codefileCmd) {
+      into "/$pathfolder"
+      rename {
+        "frccode${frcYear}.cmd"
+      }
     }
-  }
+  } else {
+    zip.from (varsfilesh) {
+      into "/$pathfolder"
+      rename {
+        "frcvars${frcYear}.sh"
+      }
+    }
 
     zip.from (codefile) {
-    into "/$pathfolder"
-    rename {
-      "frccode${frcYear}"
-    }
-  }
-
-  zip.from (codefileCmd) {
-    into "/$pathfolder"
-    rename {
-      "frccode${frcYear}.cmd"
+      into "/$pathfolder"
+      rename {
+        "frccode${frcYear}"
+      }
     }
   }
 
@@ -67,24 +69,26 @@ ext.varsZipSetup = { AbstractArchiveTask zip->
     into "/$pathfolder"
   }
 
-  zip.from (codeAppArmorFile) {
-    into "/$pathfolder/AppArmor"
-    rename {
-      "frccode"
+  if (project.ext.buildClassifier == 'Linux') {
+    zip.from (codeAppArmorFile) {
+      into "/$pathfolder/AppArmor"
+      rename {
+        "frccode"
+      }
     }
-  }
 
-  zip.from (utilAppArmorFile) {
-    into "/$pathfolder/AppArmor"
-    rename {
-      "wpilibutility"
+    zip.from (utilAppArmorFile) {
+      into "/$pathfolder/AppArmor"
+      rename {
+        "wpilibutility"
+      }
     }
-  }
 
-  zip.from (advantagescopeAppArmorFile) {
-    into "/$pathfolder/AppArmor"
-    rename {
-      "advantagescope"
+    zip.from (advantagescopeAppArmorFile) {
+      into "/$pathfolder/AppArmor"
+      rename {
+        "advantagescope"
+      }
     }
   }
 }


### PR DESCRIPTION
AppArmor files are only installed on Linux and the script files that are installed depends on the platform (fixes #415).