### PR TITLE
Upgrade Choreo

### DIFF
--- a/scripts/versions.gradle
+++ b/scripts/versions.gradle
@@ -23,7 +23,7 @@ ext.jdkVersion = '17.0.12+7'
 
 ext.advantagescopeGitTag = 'v4.0.0-beta-1'
 
-ext.choreoGitTag = 'v2025.0.0-beta-4'
+ext.choreoGitTag = 'v2025.0.0-beta-5'
 
 ext.frcYear = '2025'
 


### PR DESCRIPTION
This makes the macOS standalone binary name match Linux so the choreo.sh launcher works on macOS.