### PR TITLE
Upgrade to Choreo 2025.0.0-beta-6

### DIFF
--- a/scripts/versions.gradle
+++ b/scripts/versions.gradle
@@ -23,7 +23,7 @@ ext.jdkVersion = '17.0.12+7'
 
 ext.advantagescopeGitTag = 'v4.0.0-beta-1'
 
-ext.choreoGitTag = 'v2025.0.0-beta-5'
+ext.choreoGitTag = 'v2025.0.0-beta-6'
 
 ext.frcYear = '2025'
 


### PR DESCRIPTION
This mainly fixes ChoreoLib linking to 2024 NI libraries.