### PR TITLE
Define java.configuration.runtimes in settings.json

### DIFF
--- a/WPILibInstaller-Avalonia/ViewModels/InstallPageViewModel.cs
+++ b/WPILibInstaller-Avalonia/ViewModels/InstallPageViewModel.cs
@@ -363,6 +363,45 @@ namespace WPILibInstaller.ViewModels
                 }
             }
 
+            if (settingsJson.ContainsKey("java.configuration.runtimes"))
+            {
+                JArray javaConfigEnv = (JArray)settingsJson["java.configuration.runtimes"]!;
+                Boolean javaFound = false;
+                foreach (JToken result in javaConfigEnv)
+                {
+                    JToken? name = result["name"];
+                    if (name != null)
+                    {
+                        if (name.ToString().Equals("JavaSE-17"))
+                        {
+                            result["path"] = Path.Combine(homePath, "jdk");
+                            javaFound = true;
+                        }
+                    }
+                }
+                if (!javaFound)
+                {
+                    JObject javaConfigProp = new JObject
+                    {
+                        ["name"] = "JavaSE-17",
+                        ["path"] = Path.Combine(homePath, "jdk")
+                    };
+                    javaConfigEnv.Add(javaConfigProp);
+                    settingsJson["java.configuration.runtimes"] = javaConfigEnv;
+                }
+            }
+            else
+            {
+                JArray javaConfigProps = new JArray();
+                JObject javaConfigProp = new JObject
+                {
+                    ["name"] = "JavaSE-17",
+                    ["path"] = Path.Combine(homePath, "jdk")
+                };
+                javaConfigProps.Add(javaConfigProp);
+                settingsJson["java.configuration.runtimes"] = javaConfigProps;
+            }
+
             var serialized = JsonConvert.SerializeObject(settingsJson, Formatting.Indented);
             await File.WriteAllTextAsync(settingsFile, serialized);
         }

--- a/WPILibInstaller-Avalonia/ViewModels/InstallPageViewModel.cs
+++ b/WPILibInstaller-Avalonia/ViewModels/InstallPageViewModel.cs
@@ -375,7 +375,12 @@ namespace WPILibInstaller.ViewModels
                         if (name.ToString().Equals("JavaSE-17"))
                         {
                             result["path"] = Path.Combine(homePath, "jdk");
+                            result["default"] = true;
                             javaFound = true;
+                        }
+                        else
+                        {
+                            result["default"] = false;
                         }
                     }
                 }
@@ -384,7 +389,8 @@ namespace WPILibInstaller.ViewModels
                     JObject javaConfigProp = new JObject
                     {
                         ["name"] = "JavaSE-17",
-                        ["path"] = Path.Combine(homePath, "jdk")
+                        ["path"] = Path.Combine(homePath, "jdk"),
+                        ["default"] = true
                     };
                     javaConfigEnv.Add(javaConfigProp);
                     settingsJson["java.configuration.runtimes"] = javaConfigEnv;
@@ -396,7 +402,8 @@ namespace WPILibInstaller.ViewModels
                 JObject javaConfigProp = new JObject
                 {
                     ["name"] = "JavaSE-17",
-                    ["path"] = Path.Combine(homePath, "jdk")
+                    ["path"] = Path.Combine(homePath, "jdk"),
+                    ["default"] = "true"
                 };
                 javaConfigProps.Add(javaConfigProp);
                 settingsJson["java.configuration.runtimes"] = javaConfigProps;


### PR DESCRIPTION
If java.configuration.runtimes doesn't exist, set JavaSE-17 to WPILib JDK
If it does exist, but JavaSE-17 isn't defined, add a JavaSE-17 entry, set to WPILib JDK
If JavaSE-17 is defined, override it to WPILib JDK
Fixes wpilibsuite/allwpilib#6837
Fixes wpilibsuite/vscode-wpilib#655