### PR TITLE
Make java.configuration.runtimes.default a boolean instead of a string

### DIFF
--- a/WPILibInstaller-Avalonia/ViewModels/InstallPageViewModel.cs
+++ b/WPILibInstaller-Avalonia/ViewModels/InstallPageViewModel.cs
@@ -404,7 +404,7 @@ namespace WPILibInstaller.ViewModels
                 {
                     ["name"] = "JavaSE-17",
                     ["path"] = Path.Combine(homePath, "jdk"),
-                    ["default"] = "true"
+                    ["default"] = true
                 };
                 javaConfigProps.Add(javaConfigProp);
                 settingsJson["java.configuration.runtimes"] = javaConfigProps;


### PR DESCRIPTION
Fixes this error. 
![image](https://github.com/user-attachments/assets/c7fb3145-b2b6-450e-bae6-a46a60489680)
The rest of them seemed to be fine, it was just this one that was messed up.