### PR TITLE
Revert Skia to built in dependency

### DIFF
--- a/WPILibInstaller-Avalonia/WPILibInstaller-Avalonia.csproj
+++ b/WPILibInstaller-Avalonia/WPILibInstaller-Avalonia.csproj
@@ -55,8 +55,6 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="SharpZipLib" Version="1.4.2" />
     <PackageReference Include="Dotnet.Bundle" Version="0.9.13" />
-    <PackageReference Include="SkiaSharp" Version="2.88.9" />
-    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="2.88.9" />
     <PackageReference Include="System.Drawing.Common" Version="4.7.3" />
   </ItemGroup>
   <ItemGroup>
@@ -105,6 +103,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-j7hp-h8jx-5ppr" />
     <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-5f2m-466j-3848" />
     <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-x5qj-9vmx-7g6g" />
     <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-xhfc-gr8f-ffwc" />


### PR DESCRIPTION
The newer version seems to get flagged to to a brotli update. We have to suppress a vulnerability issue, but its in a subsystem we don't use