### PR TITLE
Select tarballs for VSCode on Linux ARM

### DIFF
--- a/WPILibInstaller-Avalonia/ViewModels/VSCodePageViewModel.cs
+++ b/WPILibInstaller-Avalonia/ViewModels/VSCodePageViewModel.cs
@@ -185,7 +185,7 @@ namespace WPILibInstaller.ViewModels
             var currentPlatform = PlatformUtils.CurrentPlatform;
             String extension;
 
-            if (currentPlatform == Platform.Linux64)
+            if (currentPlatform == Platform.Linux64 || currentPlatform == Platform.LinuxArm64)
             {
                 extension = "tar.gz";
             }


### PR DESCRIPTION
Currently on my Raspberry Pi I cannot use my existing VS Code archive for offline installation:

![screenshot of broken vscode linux arm file picker](https://github.com/user-attachments/assets/98532eed-447b-4822-b5ca-62248f1133ce)
