### PR TITLE
Fix VS Code path to handle renamed .app files on macos

### DIFF
--- a/WPILibInstaller-Avalonia/ViewModels/InstallPageViewModel.cs
+++ b/WPILibInstaller-Avalonia/ViewModels/InstallPageViewModel.cs
@@ -770,7 +770,12 @@ StartupWMClass={wmClass}
                     break;
                 case Platform.MacArm64:
                 case Platform.Mac64:
-                    codeExe = Path.Combine(configurationProvider.InstallDirectory, "vscode", "Visual Studio Code.app", "Contents", "Resources", "app", "bin", "code");
+                    var appDirectories = Directory.GetDirectories(Path.Combine(configurationProvider.InstallDirectory, "vscode"), "*.app");
+                    if (appDirectories.Length != 1)
+                    {
+                        throw new InvalidOperationException("Expected exactly one .app directory in the vscode folder.");
+                    }
+                    codeExe = Path.Combine(appDirectories[0], "Contents", "Resources", "app", "bin", "code");
                     break;
                 case Platform.Linux64:
                     codeExe = Path.Combine(configurationProvider.InstallDirectory, "vscode", "VSCode-linux-x64", "bin", "code");


### PR DESCRIPTION
closes #518 

Update `RunVsCodeExtensionsSetup` method in `InstallPageViewModel.cs` to dynamically find the .app file in the `configurationProvider.InstallDirectory`.

* Use `Directory.GetDirectories` to find the .app file in the `vscode` folder.
* Update the `codeExe` variable to use the dynamically found .app file path.
* Throw an `InvalidOperationException` if there is not exactly one .app directory in the `vscode` folder.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/wpilibsuite/WPILibInstaller-Avalonia/pull/519?shareId=67531071-7b83-4f46-9998-e4398c208bb8).