### PR TITLE
Rename linux desktop files

### DIFF
--- a/WPILibInstaller-Avalonia/ViewModels/InstallPageViewModel.cs
+++ b/WPILibInstaller-Avalonia/ViewModels/InstallPageViewModel.cs
@@ -33,7 +33,7 @@ namespace WPILibInstaller.ViewModels
 
         private async void CreateLinuxShortcut(String name, String frcYear, String wmClass, CancellationToken token)
         {
-            var launcherFile = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".local/share/applications", $@"{name} {frcYear}.desktop");
+            var launcherFile = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".local/share/applications", $@"{name.Replace(' ', '_').Replace(")", "").Replace("(", "")}_{frcYear}.desktop");
             string contents;
             if (name.Contains("WPILib"))
             {
@@ -1001,7 +1001,7 @@ StartupWMClass={wmClass}
                 {
                     // Create Linux desktop shortcut
                     var desktopFile = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "Desktop", $@"FRC VS Code {frcYear}.desktop");
-                    var launcherFile = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".local/share/applications", $@"FRC VS Code {frcYear}.desktop");
+                    var launcherFile = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".local/share/applications", $@"FRC_VS_Code_{frcYear}.desktop");
                     string contents = $@"#!/usr/bin/env xdg-open
 [Desktop Entry]
 Version=1.0


### PR DESCRIPTION
The [desktop file entry spec](https://specifications.freedesktop.org/desktop-entry-spec/latest/file-naming.html) states that only alpha-numeric characters, dashes, and underscores are valid in desktop file names. The WPILib installer created files with spaces and parentheses, which caused issues for me when trying to launch any apps. This PR simply replaces spaces with underscores and removes the parentheses in just the file name, the actual display name is not changed.
