### PR TITLE
Show deprecated message on Windows 10

### DIFF
--- a/WPILibInstaller-Avalonia/ViewModels/DeprecatedOsPageViewModel.cs
+++ b/WPILibInstaller-Avalonia/ViewModels/DeprecatedOsPageViewModel.cs
@@ -1,37 +1,65 @@
 ﻿using System;
-using System.Diagnostics;
-using System.IO;
-using System.IO.Compression;
 using System.Reactive;
-using System.Runtime.InteropServices;
-using System.Security.Cryptography;
-using System.Threading.Tasks;
-using Newtonsoft.Json;
+using Avalonia;
+using Avalonia.Controls.ApplicationLifetimes;
 using ReactiveUI;
 using WPILibInstaller.Interfaces;
-using WPILibInstaller.Models;
-using WPILibInstaller.Utils;
 
 namespace WPILibInstaller.ViewModels
 {
     public class DeprecatedOsPageViewModel : PageViewModelBase
     {
         private readonly IViewModelResolver viewModelResolver;
+        private readonly IConfigurationProvider configurationProvider;
 
-        public DeprecatedOsPageViewModel(IViewModelResolver viewModelResolver)
+        public DeprecatedOsPageViewModel(IViewModelResolver viewModelResolver, IConfigurationProvider configurationProvider)
             : base("I Understand", "")
         {
             this.viewModelResolver = viewModelResolver;
+            this.configurationProvider = configurationProvider;
+
             var version = Environment.OSVersion;
             var bitness = IntPtr.Size == 8 ? "64 Bit" : "32 Bit";
             CurrentSystem = $"Detected {version.VersionString} {bitness}";
+            bool isWindows10 = OperatingSystem.IsWindowsVersionAtLeast(10);
+            bool is64Bit = IntPtr.Size == 8;
+            if (!isWindows10 || !is64Bit)
+            {
+                DeprecatedMessage1 = "You are using an unsupported Operating System or Architecture";
+                DeprecatedMessage2 = "You will not be able to install or run WPILib " + this.configurationProvider.UpgradeConfig.FrcYear;
+            }
+            else if (isWindows10 && Environment.OSVersion.Version.Build < 22000)
+            {
+                DeprecatedMessage1 = "You are using Windows 10, which is no longer supported by Microsoft";
+                DeprecatedMessage2 = "You may not be able to install or run future year's versions of WPILib";
+            }
+            else
+            {
+                DeprecatedMessage1 = "Unknown Error";
+                DeprecatedMessage2 = "";
+            }
+
+            CancelCommand = ReactiveCommand.Create(ExitApplication);
         }
 
         public string CurrentSystem { get; }
 
+        public string DeprecatedMessage1 { get; }
+        public string DeprecatedMessage2 { get; }
+
+        public ReactiveCommand<Unit, Unit> CancelCommand { get; }
+
         public override PageViewModelBase MoveNext()
         {
-            return viewModelResolver.Resolve<StartPageViewModel>();
+            return viewModelResolver.Resolve<ConfigurationPageViewModel>();
+        }
+
+        private void ExitApplication()
+        {
+            if (Application.Current?.ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
+            {
+                desktop.Shutdown();
+            }
         }
     }
 }

--- a/WPILibInstaller-Avalonia/ViewModels/MainWindowViewModel.cs
+++ b/WPILibInstaller-Avalonia/ViewModels/MainWindowViewModel.cs
@@ -87,16 +87,6 @@ namespace WPILibInstaller.ViewModels
 
         public void Initialize()
         {
-            if (OperatingSystem.IsWindows())
-            {
-                bool isWindows10 = OperatingSystem.IsWindowsVersionAtLeast(10);
-                bool is64Bit = IntPtr.Size == 8;
-                if (!isWindows10 || !is64Bit)
-                {
-                    CurrentPage = viewModelResolver.Resolve<DeprecatedOsPageViewModel>();
-                    return;
-                }
-            }
             var startPage = viewModelResolver.Resolve<StartPageViewModel>();
             CurrentPage = startPage;
             startPage.Initialize();

--- a/WPILibInstaller-Avalonia/ViewModels/StartPageViewModel.cs
+++ b/WPILibInstaller-Avalonia/ViewModels/StartPageViewModel.cs
@@ -414,6 +414,16 @@ namespace WPILibInstaller.ViewModels
 
         public override PageViewModelBase MoveNext()
         {
+            if (OperatingSystem.IsWindows())
+            {
+                bool isWindows10 = OperatingSystem.IsWindowsVersionAtLeast(10);
+                bool is64Bit = IntPtr.Size == 8;
+                if (!isWindows10 || !is64Bit || (isWindows10 && Environment.OSVersion.Version.Build < 22000))
+                {
+                    return viewModelResolver.Resolve<DeprecatedOsPageViewModel>();
+                }
+            }
+
             return viewModelResolver.Resolve<ConfigurationPageViewModel>();
         }
 

--- a/WPILibInstaller-Avalonia/Views/DeprecatedOsPage.xaml
+++ b/WPILibInstaller-Avalonia/Views/DeprecatedOsPage.xaml
@@ -6,18 +6,18 @@
              x:Class="WPILibInstaller.Views.DeprecatedOsPage">
     <StackPanel HorizontalAlignment="Center"
               VerticalAlignment="Center">
-        <TextBlock Text="You are using an out of date Operating System or Architecture"
+        <TextBlock Text="{Binding DeprecatedMessage1}"
                HorizontalAlignment="Center"
                FontWeight="Bold"
                FontSize="25"
                VerticalAlignment="Center"
                TextAlignment="Center"
                TextWrapping="Wrap"/>
-        <TextBlock Text="You will not be able to install or run WPILib 2023"
+        <TextBlock Text="{Binding DeprecatedMessage2}"
                HorizontalAlignment="Center"
                FontSize="20"
-               VerticalAlignment="Center" />
-        <TextBlock Text="Please upgrade to at least Windows 10 64 Bit"
+               VerticalAlignment="Center"/>
+        <TextBlock Text="Please upgrade to at least Windows 11 64 Bit"
                HorizontalAlignment="Center"
                FontSize="20"
                VerticalAlignment="Center" />
@@ -29,5 +29,11 @@
                HorizontalAlignment="Center"
                VerticalAlignment="Center" 
                Text="{Binding CurrentSystem, Mode=OneWay}" /> 
+         <Button Content="Cancel"
+                HorizontalAlignment="Center"
+                Margin="20,20,20,20"
+                FontSize="20"
+                Padding="20,10"
+                Command="{Binding CancelCommand}" />
     </StackPanel>
 </UserControl>


### PR DESCRIPTION
Add a cancel button to deprecated OS window.
Windows 11 also reports as Windows 10, so it's necessary to check build numbers.
Use existing frcYear variable, which required moving the deprecated page one page later. Fixes #550