### PR TITLE
Change VSCode extensions to use OpenVSX builds

### DIFF
--- a/scripts/versions.gradle
+++ b/scripts/versions.gradle
@@ -5,8 +5,9 @@ ext.vscodeMacHash = '28159393558c4065e72b3c61ff8e0b8c74f3d2060ec5f046a91122aa881
 ext.vscodeWindowsHash = 'c6c2f97e5cb25a8b576b345f6b8f2021cc168f1726ee370f29d1dbd136ffe9f8'
 ext.vscodeLinuxArm64Hash = '33e93e2899f7a9c20d882d07b157d5fde6f1419f21c6bb95cd676d7a0412690e'
 
-ext.cppToolsVersion = '1.23.2'
+ext.cppToolsVersion = '1.23.6'
 ext.javaExtVersion = '1.38.0'
+ext.javaExtPatchVersion = '403'
 ext.javaDebugVersion = '0.58.1'
 ext.javaDependencyVersion = '0.24.1'
 ext.pythonExtVersion = '2024.22.1'

--- a/scripts/vscode.gradle
+++ b/scripts/vscode.gradle
@@ -15,15 +15,15 @@ def vscodeLinuxArm64Url = "https://update.code.visualstudio.com/${vsCodeVersion}
 
 def vscodeMacUrl = "https://update.code.visualstudio.com/${vsCodeVersion}/darwin-universal/stable".toString()
 
-def cppWindowsUrl = "https://frcmaven.wpi.edu/api/download/vscode-extensions/ms-vscode/cpptools/ms-vscode.cpptools-${cppToolsVersion}@win32-x64.vsix"
+def cppWindowsUrl = "https://github.com/microsoft/vscode-cpptools/releases/download/v${cppToolsVersion}/cpptools-windows-x64.vsix"
 
-def cppMacUrl = "https://frcmaven.wpi.edu/api/download/vscode-extensions/ms-vscode/cpptools/ms-vscode.cpptools-${cppToolsVersion}@darwin-x64.vsix"
+def cppMacUrl = "https://github.com/microsoft/vscode-cpptools/releases/download/v${cppToolsVersion}/cpptools-macOS-x64.vsix"
 
-def cppMacArmUrl = "https://frcmaven.wpi.edu/api/download/vscode-extensions/ms-vscode/cpptools/ms-vscode.cpptools-${cppToolsVersion}@darwin-arm64.vsix"
+def cppMacArmUrl = "https://github.com/microsoft/vscode-cpptools/releases/download/v${cppToolsVersion}/cpptools-macOS-arm64.vsix"
 
-def cppLinuxUrl = "https://frcmaven.wpi.edu/api/download/vscode-extensions/ms-vscode/cpptools/ms-vscode.cpptools-${cppToolsVersion}@linux-x64.vsix"
+def cppLinuxUrl = "https://github.com/microsoft/vscode-cpptools/releases/download/v${cppToolsVersion}/cpptools-linux-x64.vsix"
 
-def cppLinuxArm64Url = "https://frcmaven.wpi.edu/api/download/vscode-extensions/ms-vscode/cpptools/ms-vscode.cpptools-${cppToolsVersion}@linux-arm64.vsix"
+def cppLinuxArm64Url = "https://github.com/microsoft/vscode-cpptools/releases/download/v${cppToolsVersion}/cpptools-linux-arm64.vsix"
 
 def pythonWindowsUrl = "https://frcmaven.wpi.edu/api/download/vscode-extensions/ms-python/python/ms-python.python-${pythonExtVersion}@win32-x64.vsix"
 
@@ -37,9 +37,9 @@ def pythonLinuxArm64Url = "https://frcmaven.wpi.edu/api/download/vscode-extensio
 
 def pylanceUrl = "https://frcmaven.wpi.edu/artifactory/vscode-extensions/ms-python/vscode-pylance/ms-python.vscode-pylance-${pylanceVersion}.vsix"
 
-def isortUrl = "https://frcmaven.wpi.edu/artifactory/vscode-extensions/ms-python/isort/ms-python.isort-${isortVersion}.vsix"
+def isortUrl = "https://open-vsx.org/api/ms-python/isort/${isortVersion}/file/ms-python.isort-${isortVersion}.vsix"
 
-def blackUrl = "https://frcmaven.wpi.edu/artifactory/vscode-extensions/ms-python/black-formatter/ms-python.black-formatter-${blackVersion}.vsix"
+def blackUrl = "https://open-vsx.org/api/ms-python/black-formatter/${blackVersion}/file/ms-python.black-formatter-${blackVersion}.vsix"
 
 def wpilibExtensionUrl = "https://github.com/wpilibsuite/vscode-wpilib/releases/download/v${wpilibVersion}/vscode-wpilib-${wpilibVersion}.vsix"
 
@@ -49,11 +49,11 @@ def wpilibUtilLinuxUrl = "https://github.com/wpilibsuite/vscode-wpilib/releases/
 
 def wpilibUtilMacUrl = "https://github.com/wpilibsuite/vscode-wpilib/releases/download/v${wpilibVersion}/wpilibutility-mac.tar.gz"
 
-def javaDebugUrl = "https://frcmaven.wpi.edu/api/download/vscode-extensions/vscjava/vscode-java-debug/vscjava.vscode-java-debug-${javaDebugVersion}.vsix"
+def javaDebugUrl = "https://open-vsx.org/api/vscjava/vscode-java-debug/${javaDebugVersion}/file/vscjava.vscode-java-debug-${javaDebugVersion}.vsix"
 
-def javaLangUrl = "https://frcmaven.wpi.edu/api/download/vscode-extensions/redhat/java/redhat.java-${javaExtVersion}.vsix"
+def javaLangUrl = "https://github.com/redhat-developer/vscode-java/releases/download/v${javaExtVersion}/vscode-java-${javaExtVersion}-${javaExtPatchVersion}.vsix"
 
-def javaDepUrl = "https://frcmaven.wpi.edu/api/download/vscode-extensions/vscjava/vscode-java-dependency/vscjava.vscode-java-dependency-${javaDependencyVersion}.vsix"
+def javaDepUrl = "https://open-vsx.org/api/vscjava/vscode-java-dependency/${javaDependencyVersion}/file/vscjava.vscode-java-dependency-${javaDependencyVersion}.vsix"
 
 def vscodeWindowsDownload = tasks.register("vscodeWindowsDownload", Download) {
   src vscodeWindowsUrl


### PR DESCRIPTION
This should simplify updating versions. Only pylance and the platform specific python extensions are not availible on openVSX. The CPP extension is hosted again on github. Updated to the patch version that was hosted. We were previously using a pre-release version.