### PR TITLE
Update MavenMetadataFixer Maven plugins

### DIFF
--- a/apps/MavenMetaDataFixer/build.gradle
+++ b/apps/MavenMetaDataFixer/build.gradle
@@ -16,6 +16,6 @@ repositories {
 }
 
 dependencies {
-  implementation 'org.apache.maven:maven-repository-metadata:3.5.4'
-  implementation 'org.apache.maven:maven-model:3.5.4'
+  implementation 'org.apache.maven:maven-repository-metadata:3.9.11'
+  implementation 'org.apache.maven:maven-model:3.9.11'
 }


### PR DESCRIPTION
GSON's POM uses newer features that throw an exception with the current version. Updating to the latest stable release fixes it.