### PR TITLE
Hide recommended vscode extensions to install

### DIFF
--- a/WPILibInstaller-Avalonia/ViewModels/InstallPageViewModel.cs
+++ b/WPILibInstaller-Avalonia/ViewModels/InstallPageViewModel.cs
@@ -362,6 +362,7 @@ StartupWMClass={wmClass}
             SetIfNotSet("extensions.autoUpdate", false, settingsJson);
             SetIfNotSet("extensions.autoCheckUpdates", false, settingsJson);
             SetIfNotSet("extensions.ignoreRecommendations", true, settingsJson);
+            SetIfNotSet("extensions.showRecommendationsOnlyOnDemand", true, settingsJson);
             SetIfNotSet("update.mode", "none", settingsJson);
             SetIfNotSet("update.showReleaseNotes", false, settingsJson);
             SetIfNotSet("java.completion.matchCase", "off", settingsJson);


### PR DESCRIPTION
VSCode will recommend the VS Code Java extension pack, which will then prompt the user to install java 25 and cause issues. 
This setting is deprecated, but the recommended replacement needs manual action by users, and the method hasn't been removed in the 5 years since its been deprecated.