### PR TITLE
Fix documentation shortcut location

### DIFF
--- a/WPILibInstaller-Avalonia/ViewModels/InstallPageViewModel.cs
+++ b/WPILibInstaller-Avalonia/ViewModels/InstallPageViewModel.cs
@@ -927,8 +927,8 @@ StartupWMClass={wmClass}
             if (toInstallProvider.Model.InstallEverything)
             {
                 // Add Documentation Shortcuts
-                shortcutData.DesktopShortcuts.Add(new ShortcutInfo(Path.Join(frcHomePath, "documentation", "rtd", "frc-docs-latest", "index.html"), $"{frcYear} WPILib Documentation", $"{frcYear} WPILib Documentation", wpilibIconLocation));
-                shortcutData.StartMenuShortcuts.Add(new ShortcutInfo(Path.Join(frcHomePath, "documentation", "rtd", "frc-docs-latest", "index.html"), $"Programs/{frcYear} WPILib Documentation", $"{frcYear} WPILib Documentation", wpilibIconLocation));
+                shortcutData.DesktopShortcuts.Add(new ShortcutInfo(Path.Join(frcHomePath, "documentation", "frc-docs", "index.html"), $"{frcYear} WPILib Documentation", $"{frcYear} WPILib Documentation", wpilibIconLocation));
+                shortcutData.StartMenuShortcuts.Add(new ShortcutInfo(Path.Join(frcHomePath, "documentation", "frc-docs", "index.html"), $"Programs/{frcYear} WPILib Documentation", $"{frcYear} WPILib Documentation", wpilibIconLocation));
             }
 
             var serializedData = JsonConvert.SerializeObject(shortcutData);

--- a/scripts/maven.gradle
+++ b/scripts/maven.gradle
@@ -280,7 +280,7 @@ ext.mavenZipSetup = { AbstractArchiveTask zip->
   }
 
   zip.from(project.zipTree(downloadReadTheDocs.get().outputFiles.first())) {
-    into '/documentation/rtd'
+    into '/documentation'
   }
 
   zip.from(project.zipTree(downloadPythonAPI.get().outputFiles.first())) {


### PR DESCRIPTION
wpilibsuite/frc-docs#3159 and wpilibsuite/frc-docs#3160 changed the documentation directory from frc-docs-latest to frc-docs which makes more sense. Update shortcuts to point to the new directory. Simplify the install location, which was
documentation/rtd/frc-docs-latest to just documentation/frc-docs which should be more discoverable, since most people don't know what rtd is.