### PR TITLE
Fix Windows CRLF line break in installer when creating Linux desktop files

### DIFF
--- a/WPILibInstaller-Avalonia/ViewModels/InstallPageViewModel.cs
+++ b/WPILibInstaller-Avalonia/ViewModels/InstallPageViewModel.cs
@@ -52,7 +52,7 @@ Icon={configurationProvider.InstallDirectory}/icons/{iconName}
 Terminal=false
 StartupNotify=true
 StartupWMClass={wmClass}
-";
+".ReplaceLineEndings("\n");
             var launcherPath = Path.GetDirectoryName(launcherFile);
             if (launcherPath != null)
             {
@@ -1066,7 +1066,7 @@ Icon={configurationProvider.InstallDirectory}/icons/wpilib-icon-256.png
 Terminal=false
 StartupNotify=true
 StartupWMClass=Code
-";
+".ReplaceLineEndings("\n");
 
                     var desktopPath = Path.GetDirectoryName(desktopFile);
                     if (desktopPath != null)


### PR DESCRIPTION
A patch to use LF line breaks instead of CRLF in Linux shortcut creator