### PR TITLE
Update minimum dotnet requirement to 10.0 in Readme.md

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -6,7 +6,7 @@ Welcome to the WPILibInstaller repository, which hosts the source code used to i
 
 ### Required Dependencies
 
-- DotNetCore 8.0 or higher.
+- DotNetCore 10.0 or higher.
 - Java 17
 
 ### Building


### PR DESCRIPTION
build will not succeed on the 2027 branch unless dotnet 10 is present. 

seems like this file has the target dotnet version (which is set to 10): https://github.com/wpilibsuite/WPILibInstaller-Avalonia/blob/2027/Directory.Build.props