### PR TITLE
update Tmds.DBus.Protocol to fix build

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -15,5 +15,6 @@
     <PackageVersion Include="DotNet.ReproducibleBuilds" Version="1.2.39" />
     <PackageVersion Include="Discutils" Version="0.16.13" />
     <PackageVersion Include="System.CommandLine" Version="2.0.2" />
+    <PackageVersion Include="Tmds.DBus.Protocol" Version="0.92.0" />
   </ItemGroup>
 </Project>

--- a/WPILibInstaller-Avalonia/WPILibInstaller-Avalonia.csproj
+++ b/WPILibInstaller-Avalonia/WPILibInstaller-Avalonia.csproj
@@ -22,5 +22,6 @@
       <IncludeAssets Condition="'$(Configuration)' != 'Debug'">None</IncludeAssets>
       <PrivateAssets Condition="'$(Configuration)' != 'Debug'">All</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Tmds.DBus.Protocol" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
The build was failing due to https://github.com/tmds/Tmds.DBus/security/advisories/GHSA-xrw6-gwf8-vvr9. It is fixed in 0.92.0 and 0.21.3. 

The project was using 0.21.2. Should we just use the backported 0.21.3, or is bumping to 0.92.0 fine?