### PR TITLE
CI: Enable linux arm64 again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,9 @@ jobs:
           - os: ubuntu-24.04
             artifact-name: Linux
             build-options: "-PlinuxBuild"
-          # - os: ubuntu-22.04
-          #   artifact-name: LinuxArm64
-          #   build-options: "-PlinuxBuildArm64"
+          - os: ubuntu-24.04-arm
+            artifact-name: LinuxArm64
+            build-options: "-PlinuxBuildArm64"
           - os: macos-latest
             artifact-name: macOS
             build-options: "-PmacBuild"


### PR DESCRIPTION
There's a runner for it now. Use it!

Signed-off-by: crueter <crueter@eden-emu.dev>
