### PR TITLE
wpilibcode: fix bash scripting bugs

### DIFF
--- a/files/wpilibcode
+++ b/files/wpilibcode
@@ -6,5 +6,5 @@ CODE_PATH="$(realpath "$(find "$SCRIPT_PATH/../vscode" -type f -name code | grep
 if [ "$(sysctl -n kernel.apparmor_restrict_unprivileged_userns)" -eq "0" ] || [ "$(stat -c "%U" "$SANDBOX_PATH")" == "root" ] || [ -f "/etc/apparmor.wpilibcode" ]; then
 	"$CODE_PATH" "$@"
 else
-        "$CODE_PATH" --no-sandbox $@
+        "$CODE_PATH" --no-sandbox "$@"
 fi

--- a/files/wpilibcode
+++ b/files/wpilibcode
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
-SCRIPT_PATH="$(dirname "$(realpath -s "$BASH_SOURCE[0]")")"
+SCRIPT_PATH="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 SANDBOX_PATH="$(realpath "$(find "$SCRIPT_PATH/../vscode" -type f -name chrome-sandbox)")"
 CODE_PATH="$(realpath "$(find "$SCRIPT_PATH/../vscode" -type f -name code | grep bin)")"
 
 if [ "$(sysctl -n kernel.apparmor_restrict_unprivileged_userns)" -eq "0" ] || [ "$(stat -c "%U" "$SANDBOX_PATH")" == "root" ] || [ -f "/etc/apparmor.wpilibcode" ]; then
-	"$CODE_PATH" $@
+	"$CODE_PATH" "$@"
 else
         "$CODE_PATH" --no-sandbox $@
 fi


### PR DESCRIPTION
- bash arrays require {}
- the old code got lucky by specifying -s so dirname would ignore the [0]
- the new code allows to remove -s, allowing this script to be symlinked.
- correctly handle arguments with spaces (needs "$@")