### PR TITLE
Add wayland support to installer

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,15 +4,16 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Avalonia.Themes.Fluent" Version="12.0.4" />
+    <PackageVersion Include="Avalonia.Themes.Fluent" Version="12.1.1" />
+    <PackageVersion Include="Avalonia.Wayland" Version="12.1.1" />
     <PackageVersion Include="CommunityToolkit.Mvvm" Version="8.4.2" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
-    <PackageVersion Include="Avalonia" Version="12.0.4" />
-    <PackageVersion Include="Avalonia.Desktop" Version="12.0.4" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.10" />
+    <PackageVersion Include="Avalonia" Version="12.1.1" />
+    <PackageVersion Include="Avalonia.Desktop" Version="12.1.1" />
     <PackageVersion Include="Dotnet.Bundle" Version="0.9.13" />
     <PackageVersion Include="AvaloniaUI.DiagnosticsSupport" Version="2.2.3" />
     <PackageVersion Include="DotNet.ReproducibleBuilds" Version="2.0.5" />
     <PackageVersion Include="Discutils" Version="0.16.13" />
-    <PackageVersion Include="System.CommandLine" Version="2.0.9" />
+    <PackageVersion Include="System.CommandLine" Version="2.0.10" />
   </ItemGroup>
 </Project>

--- a/WPILibInstaller.GUI/Program.cs
+++ b/WPILibInstaller.GUI/Program.cs
@@ -16,8 +16,15 @@ namespace WPILibInstaller
         // Avalonia configuration, don't remove; also used by visual designer.
         public static AppBuilder BuildAvaloniaApp()
         {
-            return AppBuilder.Configure<App>()
-                .UsePlatformDetect()
+            AppBuilder builder = AppBuilder.Configure<App>()
+                .UsePlatformDetect();
+
+            if (!File.Exists(Path.Combine(AppContext.BaseDirectory, "ForceX11.txt")))
+            {
+                builder.UseWaylandWithFallback();
+            }
+
+            return builder
                 .ConfigureFonts(fonts =>
                 {
                     fonts.AddFontCollection(new RobotoFontCollection());

--- a/WPILibInstaller.GUI/WPILibInstaller.GUI.csproj
+++ b/WPILibInstaller.GUI/WPILibInstaller.GUI.csproj
@@ -16,6 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Avalonia.Wayland" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Avalonia" />
     <PackageReference Include="Avalonia.Desktop" />


### PR DESCRIPTION
If you place a 'ForceX11.txt' file next to the executable, it will force x11. Also if the system is not running wayland, it will automatically fall back

Closes #605 