### PR TITLE
Update version for alpha 7

### DIFF
--- a/scripts/toolchain.gradle
+++ b/scripts/toolchain.gradle
@@ -2,23 +2,23 @@ apply from: 'scripts/versions.gradle'
 
 def baseUrl = "https://github.com/wpilibsuite/opensdk/releases/download/$toolchainGitTag/"
 
-def fileNameWindows = "arm64-bookworm-2025-x86_64-w64-mingw32-Toolchain-${gccVersion}.zip"
+def fileNameWindows = "arm64-systemcore-2027-x86_64-w64-mingw32-Toolchain-${gccVersion}.tgz"
 
 def downloadUrlWindows = baseUrl + fileNameWindows
 
-def fileNameMac = "arm64-bookworm-2025-x86_64-apple-darwin-Toolchain-${gccVersion}.tgz"
+def fileNameMac = "arm64-systemcore-2027-x86_64-apple-darwin-Toolchain-${gccVersion}.tgz"
 
 def downloadUrlMac = baseUrl + fileNameMac
 
-def fileNameMacArm = "arm64-bookworm-2025-arm64-apple-darwin-Toolchain-${gccVersion}.tgz"
+def fileNameMacArm = "arm64-systemcore-2027-arm64-apple-darwin-Toolchain-${gccVersion}.tgz"
 
 def downloadUrlMacArm = baseUrl + fileNameMacArm
 
-def fileNameLinux = "arm64-bookworm-2025-x86_64-linux-gnu-Toolchain-${gccVersion}.tgz"
+def fileNameLinux = "arm64-systemcore-2027-x86_64-linux-gnu-Toolchain-${gccVersion}.tgz"
 
 def downloadUrlLinux = baseUrl + fileNameLinux
 
-def fileNameLinuxArm64 = "arm64-bookworm-2025-aarch64-bookworm-linux-gnu-Toolchain-${gccVersion}.tgz"
+def fileNameLinuxArm64 = "arm64-systemcore-2027-aarch64-bookworm-linux-gnu-Toolchain-${gccVersion}.tgz"
 
 def downloadUrlLinuxArm64 = baseUrl + fileNameLinuxArm64
 
@@ -87,10 +87,6 @@ ext.toolchainZipSetup = { AbstractArchiveTask zip->
 
     zip.from(project.tarTree(project.resources.gzip(actualLinuxTask.get().outputFiles.first()))) {
 
-      eachFile { f->
-        f.path = f.path.replace('bookworm/', 'systemcore/')
-      }
-
       includeEmptyDirs = false
     }
 
@@ -101,10 +97,6 @@ ext.toolchainZipSetup = { AbstractArchiveTask zip->
 
     zip.from(project.tarTree(project.resources.gzip(downloadTaskMac.get().outputFiles.first()))) {
 
-      eachFile { f->
-        f.path = f.path.replace('bookworm/', 'systemcore/')
-      }
-
       includeEmptyDirs = false
     }
   } else if (project.hasProperty('macBuildArm64')) {
@@ -114,10 +106,6 @@ ext.toolchainZipSetup = { AbstractArchiveTask zip->
 
     zip.from(project.tarTree(project.resources.gzip(downloadTaskMacArm.get().outputFiles.first()))) {
 
-      eachFile { f->
-        f.path = f.path.replace('bookworm/', 'systemcore/')
-      }
-
       includeEmptyDirs = false
     }
   } else {
@@ -125,12 +113,7 @@ ext.toolchainZipSetup = { AbstractArchiveTask zip->
 
     zip.inputs.files downloadTaskWindows.get().outputFiles
 
-    zip.from(project.zipTree(downloadTaskWindows.get().outputFiles.first())) {
-
-      eachFile { f->
-        f.path = f.path.replace('bookworm/', 'systemcore/')
-      }
-
+    zip.from(project.tarTree(project.resources.gzip(downloadTaskWindows.get().outputFiles.first()))) {
       includeEmptyDirs = false
     }
   }

--- a/scripts/versions.gradle
+++ b/scripts/versions.gradle
@@ -1,27 +1,27 @@
-ext.vsCodeVersion = '1.116.0'
+ext.vsCodeVersion = '1.134.0'
 
-ext.vscodeLinuxHash = 'ce87b613dc65a40304e100fc21a82271b023ef5837700f5797299041030524ba'
-ext.vscodeMacHash = 'df4f20c287dfcf33f5ad49e8dc472c8874bd924ead40e4913c4b9753fe52944b'
-ext.vscodeWindowsHash = '365c3d275deb3a1c0a1aa626f274824b8db15ee150d567a7323b8dbce2cdfa8f'
-ext.vscodeLinuxArm64Hash = '29047acc3fb79be3a0788092b372e45a8ee40b63b1a85e976b1f014536ba4184'
+ext.vscodeLinuxHash = '9336170079f527f1ca62dad39947b020db06bd3e8cae7e1e6097bea594f37733'
+ext.vscodeMacHash = 'eb9d7865ce4d7041e5b971846a00cea71a01db07b3d559537e1a9b8388718d77'
+ext.vscodeWindowsHash = '59d3e1816961abb53d3bcc264083ee7e3f2282a6ff1004c4a1a8411b92a7a45d'
+ext.vscodeLinuxArm64Hash = 'a5581220fedf9c734114af64b2c8b549e0ae5e82d71cf5c951e3b4d425104b99'
 
-ext.cppToolsVersion = '1.31.4'
-ext.javaExtVersion = '1.54.0'
-ext.javaExtPatchVersion = '923'
+ext.cppToolsVersion = '1.33.8'
+ext.javaExtVersion = '1.55.0'
+ext.javaExtPatchVersion = '995'
 ext.javaDebugVersion = '0.59.0'
-ext.javaDependencyVersion = '0.27.2'
+ext.javaDependencyVersion = '0.27.6'
 
 ext.wpilibVersion = gradleRioVersion
 
-ext.gccVersion = '12.2.0'
-ext.toolchainGitTag = 'v2025-2'
+ext.gccVersion = '14.3.0'
+ext.toolchainGitTag = 'v2027-1'
 
-ext.jdkVersion = '25.0.2+10'
+ext.jdkVersion = '25.0.4.1+1'
 
 ext.advantagescopeGitTag = 'v27.0.0-alpha-6'
 
 ext.elasticGitTag = 'v2027.0.0-alpha8'
 
-ext.wpilibYear = '2027_alpha5'
+ext.wpilibYear = '2027_alpha7'
 
 ext.gradleWrapperVersion = '9.4.1'

--- a/scripts/vscode.gradle
+++ b/scripts/vscode.gradle
@@ -2,6 +2,8 @@ apply from: 'scripts/versions.gradle'
 
 def vscodeFile = file("$buildDir/vscodeConfig.json")
 
+def wpilibVersion = '2027.0.0-alpha-6'
+
 def vscodeWindowsZipName = "VSCode-${vsCodeVersion}-Windows.zip".toString()
 def vscodeLinuxZipName = "VSCode-${vsCodeVersion}-Linux.tar.gz".toString()
 def vscodeLinuxArm64ZipName = "VSCode-${vsCodeVersion}-LinuxArm64.tar.gz".toString()


### PR DESCRIPTION
VS Code 1.116 to 1.134
CPP extension 1.31.4 to 1.33.8
Java extension 1.54.0 to 1.55.0
Java Dependency extension 0.27.2 to 0.27.6
JDK 25.0.2+10 to 25.0.4.1+1
toolchain from 12.2.0 to 14.3.0
handle toolchain switching from zip to tgz on Windows