### PR TITLE
Make vscode prompt to trust when opening new workspaces

### DIFF
--- a/WPILibInstaller.Common/Services/VsCodeInstallationService.cs
+++ b/WPILibInstaller.Common/Services/VsCodeInstallationService.cs
@@ -138,6 +138,7 @@ namespace WPILibInstaller.Services
             SetIfNotSetIgnoreSync("update.showReleaseNotes", false, settingsJson);
             SetIfNotSetIgnoreSync("java.completion.matchCase", "off", settingsJson);
             SetIfNotSetIgnoreSync("workbench.secondarySideBar.defaultVisibility", "hidden", settingsJson);
+            SetIfNotSetIgnoreSync("security.workspace.trust.startupPrompt", "once", settingsJson);
 
             string os;
             string pathSeparator;


### PR DESCRIPTION
This was changed to default to "never" in latest upstream VSCode, which makes it only display the small banner at the top which is easy to miss.

