### PR TITLE
Extract gradle wrapper to GRADLE_USER_HOME if set

### DIFF
--- a/WPILibInstaller.Common/Services/ToolInstallationService.cs
+++ b/WPILibInstaller.Common/Services/ToolInstallationService.cs
@@ -22,10 +22,12 @@ namespace WPILibInstaller.Services
             string gradleZipLoc = Path.Combine(extractFolder, "installUtils", config.Gradle.ZipName);
 
             string userFolder = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+            string gradleUserHome = Environment.GetEnvironmentVariable("GRADLE_USER_HOME") ?? Path.Combine(userFolder, ".gradle");
+
             List<Task> tasks = new();
             foreach (var extractLocation in config.Gradle.ExtractLocations)
             {
-                string toFolder = Path.Combine(userFolder, ".gradle", extractLocation, Path.GetFileNameWithoutExtension(config.Gradle.ZipName), config.Gradle.Hash);
+                string toFolder = Path.Combine(gradleUserHome, extractLocation, Path.GetFileNameWithoutExtension(config.Gradle.ZipName), config.Gradle.Hash);
                 string toFile = Path.Combine(toFolder, config.Gradle.ZipName);
                 tasks.Add(Task.Run(() =>
                 {


### PR DESCRIPTION
Currently, if the user has GRADLE\_USER\_HOME set to something other than \~/.gradle, the offline install won't work as gradle will look in GRADLE\_USER\_HOME.



